### PR TITLE
Feat/backend/user profile

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "@scalar/hono-api-reference": "^0.10.5",
         "@types/iso-3166-2": "^1.0.4",
         "bcryptjs": "^3.0.3",
+        "cpf-cnpj-validator": "^2.1.0",
         "cross-env": "^10.1.0",
         "dotenv": "^17.4.0",
         "dotenv-expand": "^12.0.3",
@@ -5924,6 +5925,43 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cpf-cnpj-validator": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cpf-cnpj-validator/-/cpf-cnpj-validator-2.1.0.tgz",
+      "integrity": "sha512-tgSVKy8EK8LMRYRtoTfPICQ5innN0go/aqokEAF66HW466MHDsjBGkyPOY0KmCJ+k7Jh0CG9m70YHp30yiOCLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@angular/forms": ">=15",
+        "class-validator": "^0.14.0 || ^0.15.0",
+        "joi": "^17.0.0",
+        "reflect-metadata": "^0.2.0",
+        "yup": "^1.0.0",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/forms": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        },
+        "joi": {
+          "optional": true
+        },
+        "reflect-metadata": {
+          "optional": true
+        },
+        "yup": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cpu-features": {
       "version": "0.0.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "@scalar/hono-api-reference": "^0.10.5",
     "@types/iso-3166-2": "^1.0.4",
     "bcryptjs": "^3.0.3",
+    "cpf-cnpj-validator": "^2.1.0",
     "cross-env": "^10.1.0",
     "dotenv": "^17.4.0",
     "dotenv-expand": "^12.0.3",

--- a/backend/prisma/migrations/20260508011223_add_user_profile/migration.sql
+++ b/backend/prisma/migrations/20260508011223_add_user_profile/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "Profile" (
+    "id" TEXT NOT NULL,
+    "cpf" TEXT,
+    "rgPassaporte" TEXT,
+    "birthDate" TIMESTAMP(3),
+    "profession" TEXT,
+    "address" TEXT,
+    "bankCode" TEXT,
+    "bankName" TEXT,
+    "bankAgency" TEXT,
+    "bankAccount" TEXT,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_cpf_key" ON "Profile"("cpf");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_userId_key" ON "Profile"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,6 +17,26 @@ model User {
   isActive        Boolean          @default(true)
   createdAt       DateTime         @default(now())
   updatedAt       DateTime         @updatedAt
+  profile         Profile?
+}
+
+model Profile {
+  id            String    @id @default(uuid())
+  cpf           String?   @unique
+  rgPassaporte  String?
+  birthDate     DateTime?
+  profession    String?
+  address       String?
+  bankCode      String?
+  bankName      String?
+  bankAgency    String?
+  bankAccount   String?
+  
+  userId String @unique
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 enum UserRole {

--- a/backend/src/constants/seed.constant.ts
+++ b/backend/src/constants/seed.constant.ts
@@ -1,3 +1,5 @@
+import { cpf } from 'cpf-cnpj-validator'
+
 const ID_ALUNO = 'c341c8fa-724f-4ab2-9a4e-5ca55f201ad4'
 const ID_PROJ_ROBOTICA = 'a1b2c3d4-e5f6-4a5b-8c9d-0123456789ab'
 const ID_PROJ_DATA_SCIENCE = '4aa1fe1f-5c8b-4fd5-999b-adf0195b0ccb'
@@ -5,10 +7,31 @@ const ID_PROJ_DATA_SCIENCE = '4aa1fe1f-5c8b-4fd5-999b-adf0195b0ccb'
 const ID_PROJ_IA = 'b2c3d4e5-f6a7-5b6c-9d0e-1234567890bc'
 const DEFAULT_USER_PASSWORD = 'Test@1234'
 
+const MOCK_PROFILE = {
+  cpf: cpf.generate(),
+  rgPassaporte: 'MG-12.345.678',
+  birthDate: '2000-01-01T00:00:00.000Z',
+  profession: 'Estudante',
+  address: 'Rua das Flores, 123',
+  bankCode: '001',
+  bankName: 'BANCO DO BRASIL',
+  bankAgency: '1234-5',
+  bankAccount: '12345678',
+} as const
+
+const MOCK_USER = {
+  name: 'João Silva',
+  email: 'usuario@exemplo.com',
+  password: 'P@ssw0rd123',
+  inviteCode: 'CONVITE2026',
+} as const
+
 export {
   DEFAULT_USER_PASSWORD,
   ID_ALUNO,
   ID_PROJ_DATA_SCIENCE,
   ID_PROJ_IA,
   ID_PROJ_ROBOTICA,
+  MOCK_PROFILE,
+  MOCK_USER,
 }

--- a/backend/src/constants/user.constant.ts
+++ b/backend/src/constants/user.constant.ts
@@ -1,0 +1,10 @@
+import { UserRole } from '@/generated/prisma/enums'
+
+export const USER_ERROR_CODES = {
+  CPF_ALREADY_USED: 'CPF_ALREADY_USED',
+  PROFILE_UPDATE_NOT_ALLOWED: 'PROFILE_UPDATE_NOT_ALLOWED',
+} as const
+
+export const ROLES_ALLOWED_TO_HAVE_PROFILE: UserRole[] = [
+  UserRole.ALUNO,
+] as const

--- a/backend/src/routes/auth/auth.route.ts
+++ b/backend/src/routes/auth/auth.route.ts
@@ -14,7 +14,7 @@ export const register = createRoute({
   path: '/register',
   method: 'post',
   summary: 'Register user',
-  description: 'Registrar um novo usuário no sistema.',
+  description: 'Registra um novo usuário no sistema. O payload exigido varia de acordo com o papel: Alunos devem enviar dados de perfil completos. Coordenadores e Admins exigem apenas credenciais básicas.',
   tags,
   request: { body: jsonContentRequired(RegisterSchema, 'User credentials') },
   responses: {

--- a/backend/src/routes/me/index.ts
+++ b/backend/src/routes/me/index.ts
@@ -4,5 +4,6 @@ import * as routes from './me.route'
 
 const router = createRouter().basePath('/me')
   .openapi(routes.index, handlers.index)
+  .openapi(routes.update, handlers.update)
 
 export default router

--- a/backend/src/routes/me/me.handler.ts
+++ b/backend/src/routes/me/me.handler.ts
@@ -1,7 +1,10 @@
-import type { IndexRoute } from './me.route'
+import type { IndexRoute, UpdateRoute } from './me.route'
 import type { AppRouteHandler } from '@/lib/type'
 import * as codes from 'stoker/http-status-codes'
-import { getUserById } from '@/services/user.service'
+import * as phrases from 'stoker/http-status-phrases'
+import { USER_ERROR_CODES } from '@/constants/user.constant'
+import { UserSchema } from '@/schemas/user.schema'
+import { getUserById, updateUser } from '@/services/user.service'
 
 export const index: AppRouteHandler<IndexRoute> = async (c) => {
   const { sub } = c.get('jwtPayload')
@@ -13,4 +16,35 @@ export const index: AppRouteHandler<IndexRoute> = async (c) => {
   }
 
   return c.json(userProfile, codes.OK)
+}
+
+export const update: AppRouteHandler<UpdateRoute> = async (c) => {
+  const { sub } = c.get('jwtPayload')
+  const data = c.req.valid('json')
+
+  const result = await updateUser(sub, data)
+
+  if ('error' in result) {
+    switch (result.error) {
+      case USER_ERROR_CODES.CPF_ALREADY_USED:
+        return c.json(
+          { message: 'O CPF informado já está em uso por outro usuário.' },
+          codes.CONFLICT,
+        )
+
+      case USER_ERROR_CODES.PROFILE_UPDATE_NOT_ALLOWED:
+        return c.json(
+          { message: 'Acesso negado: Apenas alunos podem atualizar dados de perfil.' },
+          codes.FORBIDDEN,
+        )
+
+      case phrases.NOT_FOUND:
+        return c.json(
+          { message: 'O usuário não foi encontrado no sistema.' },
+          codes.NOT_FOUND,
+        )
+    }
+  }
+  const parsed = UserSchema.parse(result)
+  return c.json(parsed, codes.OK)
 }

--- a/backend/src/routes/me/me.route.ts
+++ b/backend/src/routes/me/me.route.ts
@@ -4,7 +4,7 @@ import { jsonContent } from 'stoker/openapi/helpers'
 import { createMessageObjectSchema } from 'stoker/openapi/schemas'
 import { requireAuth } from '@/middlewares'
 import { UnauthorizedResponse } from '@/schemas/shared.schema'
-import { UserSchema } from '@/schemas/user.schema'
+import { UpdateProfileSchema, UserSchema } from '@/schemas/user.schema'
 
 const tags = ['Me']
 
@@ -27,6 +27,38 @@ export const index = createRoute({
     [codes.NOT_FOUND]: jsonContent(
       createMessageObjectSchema('Usuário não encontrado'),
       'Erro: O usuário correspondente ao token não existe mais no banco de dados.',
+    ),
+  },
+})
+
+export type UpdateRoute = typeof update
+
+export const update = createRoute({
+  path: '/',
+  method: 'patch',
+  summary: 'Update current user profile',
+  description: 'Atualiza os dados do perfil do usuário autenticado.',
+  tags,
+  middleware: [requireAuth],
+  security: [{ Bearer: [] }],
+  request: { body: jsonContent(UpdateProfileSchema, 'Dados do perfil para atualização') },
+  responses: {
+    [codes.OK]: jsonContent(
+      UserSchema,
+      'Perfil atualizado com sucesso.',
+    ),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+    [codes.FORBIDDEN]: jsonContent(
+      createMessageObjectSchema('Acesso negado'),
+      'Apenas alunos podem atualizar dados de perfil.',
+    ),
+    [codes.CONFLICT]: jsonContent(
+      createMessageObjectSchema('Conflito de CPF'),
+      'O CPF informado já está em uso por outro usuário.',
+    ),
+    [codes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Usuário não encontrado'),
+      'O usuário não foi encontrado no sistema.',
     ),
   },
 })

--- a/backend/src/routes/me/me.route.ts
+++ b/backend/src/routes/me/me.route.ts
@@ -4,7 +4,7 @@ import { jsonContent } from 'stoker/openapi/helpers'
 import { createMessageObjectSchema } from 'stoker/openapi/schemas'
 import { requireAuth } from '@/middlewares'
 import { UnauthorizedResponse } from '@/schemas/shared.schema'
-import { UserProfileSchema } from '@/schemas/user.schema'
+import { UserSchema } from '@/schemas/user.schema'
 
 const tags = ['Me']
 
@@ -20,7 +20,7 @@ export const index = createRoute({
   security: [{ Bearer: [] }],
   responses: {
     [codes.OK]: jsonContent(
-      UserProfileSchema,
+      UserSchema,
       'Perfil do usuário retornado com sucesso.',
     ),
     [codes.UNAUTHORIZED]: UnauthorizedResponse,

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -1,10 +1,12 @@
 import { z } from '@hono/zod-openapi'
+import { MOCK_USER } from '@/constants/seed.constant'
 import { UserRole } from '@/generated/prisma/enums'
-import { UserSchema } from './user.schema'
+import { validBankCodeCheck, validBirthDate } from './schema.refine'
+import { ProfileSchema, UserSchema } from './user.schema'
 
-export const RegisterSchema = z.object({
-  name: z.string().openapi({ example: 'João Silva' }),
-  email: z.email().meta({ example: 'usuario@exemplo.com' }),
+const RegisterBaseSchema = z.object({
+  name: z.string().openapi({ example: MOCK_USER.name }),
+  email: z.email().meta({ example: MOCK_USER.email }),
   password: z.string()
     .min(8, 'A senha deve ter pelo menos 8 caracteres')
     .regex(/[A-Z]/, 'A senha deve conter pelo menos uma letra maiúscula')
@@ -13,15 +15,31 @@ export const RegisterSchema = z.object({
     .regex(/[^A-Z0-9]/i, 'A senha deve conter pelo menos um caractere especial')
     .openapi({
       description: 'A senha do usuário deve ter no mínimo 8 caracteres, 1 letra maiúscula, 1 número e 1 caractere especial.',
-      example: 'P@ssw0rd123',
+      example: MOCK_USER.password,
     }),
   role: z.enum(UserRole).openapi({ examples: Object.values(UserRole) }),
-  inviteCode: z.string().openapi({ example: 'CONVITE2026' }),
+  inviteCode: z.string().openapi({ example: MOCK_USER.inviteCode }),
 })
+
+export const AlunoRegisterSchema = RegisterBaseSchema
+  .extend((ProfileSchema.required()).shape)
+  .extend({
+    role: z.literal(UserRole.ALUNO),
+    birthDate: validBirthDate,
+  })
+  .check(validBankCodeCheck)
+
+export const StaffRegisterSchema = RegisterBaseSchema
+  .extend({ role: z.enum([UserRole.ADMIN, UserRole.COORDENADOR]) })
+
+export const RegisterSchema = z.discriminatedUnion('role', [
+  StaffRegisterSchema.strict(),
+  AlunoRegisterSchema,
+])
 
 export const RegisterSuccessSchema = UserSchema
 
-export const LoginSchema = RegisterSchema.pick({
+export const LoginSchema = RegisterBaseSchema.pick({
   email: true,
   password: true,
 })

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -1,7 +1,7 @@
 import { z } from '@hono/zod-openapi'
 import { MOCK_USER } from '@/constants/seed.constant'
 import { UserRole } from '@/generated/prisma/enums'
-import { validBankCodeCheck, validBirthDate } from './schema.refine'
+import { validBankCode, validBirthDate } from './schema.refine'
 import { ProfileSchema, UserSchema } from './user.schema'
 
 const RegisterBaseSchema = z.object({
@@ -26,8 +26,8 @@ export const AlunoRegisterSchema = RegisterBaseSchema
   .extend({
     role: z.literal(UserRole.ALUNO),
     birthDate: validBirthDate,
+    bankCode: validBankCode,
   })
-  .check(validBankCodeCheck)
 
 export const StaffRegisterSchema = RegisterBaseSchema
   .extend({ role: z.enum([UserRole.ADMIN, UserRole.COORDENADOR]) })

--- a/backend/src/schemas/expense.schema.ts
+++ b/backend/src/schemas/expense.schema.ts
@@ -6,10 +6,10 @@ import { CostBreakdownResponseSchema } from './cost-breakdown.schema'
 import ProjectSchema from './project.schema'
 import { reasonFieldRequired, returnDateAfterDepartureDateCheck, stateBelongsToCountryCheck, validCountryCheck, validPDFCheck, validStateCheck } from './schema.refine'
 import { FileItemSchema, IdSchema, LocationSchema, TimestampSchema, TripPeriodSchema } from './shared.schema'
-import { UserProfileSchema } from './user.schema'
+import { UserSchema } from './user.schema'
 
 export const ExpenseRelationsSchema = {
-  student: UserProfileSchema.pick({
+  student: UserSchema.pick({
     id: true,
     name: true,
   }).optional(),

--- a/backend/src/schemas/schema.refine.ts
+++ b/backend/src/schemas/schema.refine.ts
@@ -58,3 +58,39 @@ export function validPDFCheck(maxSizeInMB: number) {
     }
   }
 }
+
+export function maskBankAccountTransform(val: string | undefined): string | undefined {
+  if (!val)
+    return val
+  return val.length > 4 ? `${val.slice(0, -4)}****` : '****'
+}
+
+export const validBirthDate = z.coerce.date().superRefine((date, ctx) => {
+  const today = new Date()
+
+  const minDate = new Date(today.getFullYear() - 120, today.getMonth(), today.getDate())
+
+  const maxDate = new Date(today.getFullYear() - 18, today.getMonth(), today.getDate())
+
+  if (date > maxDate) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Você precisa ter pelo menos 18 anos para se cadastrar.',
+    })
+  }
+
+  if (date < minDate) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Data de nascimento inválida (limite de 120 anos).',
+    })
+  }
+})
+
+export const validBankCodeCheck = z.refine<{ bankCode: string }>(
+  value => /^\d{3}$/.test(value.bankCode),
+  {
+    message: 'Código de banco inválido. Utilize um código COMPE de 3 dígitos (ex: 001).',
+    path: ['bankCode'],
+  },
+)

--- a/backend/src/schemas/schema.refine.ts
+++ b/backend/src/schemas/schema.refine.ts
@@ -62,7 +62,7 @@ export function validPDFCheck(maxSizeInMB: number) {
 export function maskBankAccountTransform(val: string | undefined): string | undefined {
   if (!val)
     return val
-  return val.length > 4 ? `${val.slice(0, -4)}****` : '****'
+  return val.length > 4 ? `****${val.slice(-4)}` : '****'
 }
 
 export const validBirthDate = z.coerce.date().superRefine((date, ctx) => {
@@ -87,10 +87,11 @@ export const validBirthDate = z.coerce.date().superRefine((date, ctx) => {
   }
 })
 
-export const validBankCodeCheck = z.refine<{ bankCode: string }>(
-  value => /^\d{3}$/.test(value.bankCode),
-  {
-    message: 'Código de banco inválido. Utilize um código COMPE de 3 dígitos (ex: 001).',
-    path: ['bankCode'],
-  },
-)
+export const validBankCode = z.string().superRefine((val, ctx) => {
+  if (!/^\d{3}$/.test(val)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Código de banco inválido. Utilize um código COMPE de 3 dígitos (ex: 001).',
+    })
+  }
+})

--- a/backend/src/schemas/user.schema.ts
+++ b/backend/src/schemas/user.schema.ts
@@ -1,13 +1,66 @@
 import { z } from '@hono/zod-openapi'
+import { zodValidator } from 'cpf-cnpj-validator/zod'
+
+import { MOCK_PROFILE, MOCK_USER } from '@/constants/seed.constant'
 import { UserRole } from '@/generated/prisma/enums'
-import { IdSchema, TimestampSchema } from '@/schemas/shared.schema'
+import { maskBankAccountTransform } from './schema.refine'
+import { IdSchema, TimestampSchema } from './shared.schema'
+
+const { cpf: zCpf } = zodValidator(z)
+
+export const ProfileSchema = z.object({
+  cpf: zCpf()
+    .openapi({ example: MOCK_PROFILE.cpf }),
+
+  rgPassaporte: z.string()
+    .trim()
+    .toUpperCase()
+    .openapi({ example: MOCK_PROFILE.rgPassaporte }),
+
+  birthDate: z.coerce.date()
+    .openapi({ example: MOCK_PROFILE.birthDate }),
+
+  profession: z.string()
+    .trim()
+    .openapi({ example: MOCK_PROFILE.profession }),
+
+  address: z.string()
+    .trim()
+    .min(5, 'O endereço deve ter pelo menos 5 caracteres.')
+    .openapi({ example: MOCK_PROFILE.address }),
+
+  bankCode: z.string()
+    .trim()
+    .length(3)
+    .openapi({ example: MOCK_PROFILE.bankCode }),
+
+  bankName: z.string()
+    .trim()
+    .toUpperCase()
+    .min(2, 'O nome do banco deve ter pelo menos 2 caracteres.')
+    .openapi({ example: MOCK_PROFILE.bankName }),
+
+  bankAgency: z.string()
+    .trim()
+    .toUpperCase()
+    .openapi({ example: MOCK_PROFILE.bankAgency }),
+
+  bankAccount: z.string()
+    .trim()
+    .toUpperCase()
+    .openapi({ example: MOCK_PROFILE.bankAccount }),
+})
 
 export const UserSchema = z.object({
   id: IdSchema,
-  name: z.string().openapi({ example: 'João Silva' }),
+  name: z.string().openapi({ example: MOCK_USER.name }),
   email: z.email()
-    .openapi({ example: 'usuario@exemplo.com' }),
+    .openapi({ example: MOCK_USER.email }),
   role: z.enum(UserRole).openapi({ examples: Object.values(UserRole) }),
+  isActive: z.boolean().openapi({ example: true }),
+  profile: ProfileSchema.partial().extend({
+    bankAccount: z.string().transform(maskBankAccountTransform),
+  })
+    .optional()
+    .nullable(),
 }).extend(TimestampSchema)
-
-export const UserProfileSchema = UserSchema

--- a/backend/src/schemas/user.schema.ts
+++ b/backend/src/schemas/user.schema.ts
@@ -3,51 +3,56 @@ import { zodValidator } from 'cpf-cnpj-validator/zod'
 
 import { MOCK_PROFILE, MOCK_USER } from '@/constants/seed.constant'
 import { UserRole } from '@/generated/prisma/enums'
-import { maskBankAccountTransform } from './schema.refine'
+import { maskBankAccountTransform, validBankCode, validBirthDate } from './schema.refine'
 import { IdSchema, TimestampSchema } from './shared.schema'
 
 const { cpf: zCpf } = zodValidator(z)
 
 export const ProfileSchema = z.object({
   cpf: zCpf()
+    .nullish()
     .openapi({ example: MOCK_PROFILE.cpf }),
 
   rgPassaporte: z.string()
     .trim()
     .toUpperCase()
+    .nullish()
     .openapi({ example: MOCK_PROFILE.rgPassaporte }),
 
-  birthDate: z.coerce.date()
+  birthDate: validBirthDate.nullish()
     .openapi({ example: MOCK_PROFILE.birthDate }),
 
   profession: z.string()
     .trim()
+    .nullish()
     .openapi({ example: MOCK_PROFILE.profession }),
 
   address: z.string()
     .trim()
     .min(5, 'O endereço deve ter pelo menos 5 caracteres.')
+    .nullish()
     .openapi({ example: MOCK_PROFILE.address }),
 
-  bankCode: z.string()
-    .trim()
-    .length(3)
+  bankCode: validBankCode.nullish()
     .openapi({ example: MOCK_PROFILE.bankCode }),
 
   bankName: z.string()
     .trim()
     .toUpperCase()
     .min(2, 'O nome do banco deve ter pelo menos 2 caracteres.')
+    .nullish()
     .openapi({ example: MOCK_PROFILE.bankName }),
 
   bankAgency: z.string()
     .trim()
     .toUpperCase()
+    .nullish()
     .openapi({ example: MOCK_PROFILE.bankAgency }),
 
   bankAccount: z.string()
     .trim()
     .toUpperCase()
+    .nullish()
     .openapi({ example: MOCK_PROFILE.bankAccount }),
 })
 
@@ -58,9 +63,11 @@ export const UserSchema = z.object({
     .openapi({ example: MOCK_USER.email }),
   role: z.enum(UserRole).openapi({ examples: Object.values(UserRole) }),
   isActive: z.boolean().openapi({ example: true }),
-  profile: ProfileSchema.partial().extend({
-    bankAccount: z.string().transform(maskBankAccountTransform),
+  profile: ProfileSchema.extend({
+    bankAccount: z.string().transform(maskBankAccountTransform)
+      .nullish(),
   })
-    .optional()
-    .nullable(),
+    .nullish(),
 }).extend(TimestampSchema)
+
+export const UpdateProfileSchema = ProfileSchema.partial().extend({ name: z.string().optional() })

--- a/backend/src/seeds/user.seed.ts
+++ b/backend/src/seeds/user.seed.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import type { Prisma } from '@/generated/prisma/client'
 import { genSalt, hash } from 'bcryptjs'
-import { DEFAULT_USER_PASSWORD, ID_ALUNO } from '@/constants/seed.constant'
+import { DEFAULT_USER_PASSWORD, ID_ALUNO, MOCK_PROFILE } from '@/constants/seed.constant'
 import env from '@/env'
 import { UserRole } from '@/generated/prisma/client'
 import prisma from '@/lib/orm'
@@ -24,6 +24,15 @@ export const dummyUsers: Omit<Prisma.UserCreateInput, 'passwordHash'>[] = [
     email: 'aluno@test.com',
     name: 'Codibentinho',
     role: UserRole.ALUNO,
+    profile: {
+      connectOrCreate: {
+        where: { userId: ID_ALUNO },
+        create: {
+          ...MOCK_PROFILE,
+          birthDate: new Date(MOCK_PROFILE.birthDate),
+        },
+      },
+    },
   },
 ]
 

--- a/backend/src/seeds/user.seed.ts
+++ b/backend/src/seeds/user.seed.ts
@@ -14,7 +14,7 @@ export const dummyUsers: Omit<Prisma.UserCreateInput, 'passwordHash'>[] = [
     role: UserRole.COORDENADOR,
   },
   {
-    id: 'a1b2c3d4-e5f6-4g7h-8i9j-0k1l2m3n4o5p',
+    id: '48d413bc-0566-444e-9648-303506d50a61',
     email: 'admin@test.com',
     name: 'Administrador',
     role: UserRole.ADMIN,

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,6 +1,8 @@
 import type { z } from '@hono/zod-openapi'
+import type { ProfileCreateWithoutUserInput } from '@/generated/prisma/models'
 import type { RegisterSchema } from '@/schemas/auth.schema'
 import bcrypt from 'bcryptjs'
+import { UserRole } from '@/generated/prisma/client'
 import prisma from '@/lib/orm'
 
 const omit = { passwordHash: true }
@@ -8,15 +10,35 @@ const omit = { passwordHash: true }
 type CreateUserDTO = z.infer<typeof RegisterSchema>
 
 export async function createUser(data: CreateUserDTO, saltRounds: number) {
-  const { password, inviteCode, ...other } = data
+  const { name, email, role, password, inviteCode: _ } = data
+
   const salt = await bcrypt.genSalt(saltRounds)
   const hash = await bcrypt.hash(password, salt)
+
+  const profileData: ProfileCreateWithoutUserInput | undefined = data.role === UserRole.ALUNO
+    ? {
+        cpf: data.cpf,
+        rgPassaporte: data.rgPassaporte,
+        birthDate: data.birthDate,
+        profession: data.profession,
+        address: data.address,
+        bankCode: data.bankCode,
+        bankName: data.bankName,
+        bankAgency: data.bankAgency,
+        bankAccount: data.bankAccount,
+      }
+    : undefined
+
   return prisma.user.create({
     data: {
+      name,
+      email,
+      role,
       passwordHash: hash,
-      ...other,
+      profile: profileData ? { create: profileData } : undefined,
     },
     omit,
+    include: { profile: true },
   })
 }
 
@@ -27,14 +49,8 @@ export async function getUserByEmail(email: string) {
 export async function getUserById(id: string) {
   const user = await prisma.user.findUnique({
     where: { id },
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      role: true,
-      createdAt: true,
-      updatedAt: true,
-    },
+    omit,
+    include: { profile: true },
   })
 
   return user

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -5,7 +5,6 @@ import type { UpdateProfileSchema } from '@/schemas/user.schema'
 import bcrypt from 'bcryptjs'
 import * as phrases from 'stoker/http-status-phrases'
 import { ROLES_ALLOWED_TO_HAVE_PROFILE, USER_ERROR_CODES } from '@/constants/user.constant'
-import { UserRole } from '@/generated/prisma/client'
 import prisma from '@/lib/orm'
 
 const omit = { passwordHash: true }
@@ -19,7 +18,7 @@ export async function createUser(data: CreateUserDTO, saltRounds: number) {
   const salt = await bcrypt.genSalt(saltRounds)
   const hash = await bcrypt.hash(password, salt)
 
-  const profileData: ProfileCreateWithoutUserInput | undefined = data.role === UserRole.ALUNO
+  const profileData: ProfileCreateWithoutUserInput | undefined = data.role === 'ALUNO'
     ? {
         cpf: data.cpf,
         rgPassaporte: data.rgPassaporte,

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,13 +1,17 @@
 import type { z } from '@hono/zod-openapi'
 import type { ProfileCreateWithoutUserInput } from '@/generated/prisma/models'
 import type { RegisterSchema } from '@/schemas/auth.schema'
+import type { UpdateProfileSchema } from '@/schemas/user.schema'
 import bcrypt from 'bcryptjs'
+import * as phrases from 'stoker/http-status-phrases'
+import { ROLES_ALLOWED_TO_HAVE_PROFILE, USER_ERROR_CODES } from '@/constants/user.constant'
 import { UserRole } from '@/generated/prisma/client'
 import prisma from '@/lib/orm'
 
 const omit = { passwordHash: true }
 
 type CreateUserDTO = z.infer<typeof RegisterSchema>
+type UpdateUserDTO = z.infer<typeof UpdateProfileSchema>
 
 export async function createUser(data: CreateUserDTO, saltRounds: number) {
   const { name, email, role, password, inviteCode: _ } = data
@@ -54,4 +58,51 @@ export async function getUserById(id: string) {
   })
 
   return user
+}
+
+export async function updateUser(id: string, data: UpdateUserDTO) {
+  const { name, ...profileData } = data
+
+  const user = await getUserById(id)
+
+  if (!user) {
+    return { error: phrases.NOT_FOUND }
+  }
+
+  const hasProfileData = Object.values(profileData).some(val => val !== undefined)
+
+  if (!ROLES_ALLOWED_TO_HAVE_PROFILE.includes(user.role) && hasProfileData) {
+    return { error: USER_ERROR_CODES.PROFILE_UPDATE_NOT_ALLOWED }
+  }
+
+  if (profileData.cpf && profileData.cpf !== user.profile?.cpf) {
+    const cpfInUseByAnotherUser = await prisma.profile.findFirst({
+      where: {
+        cpf: profileData.cpf,
+        userId: { not: id },
+      },
+      select: { id: true },
+    })
+
+    if (cpfInUseByAnotherUser) {
+      return { error: USER_ERROR_CODES.CPF_ALREADY_USED }
+    }
+  }
+
+  return prisma.user.update({
+    where: { id },
+    data: {
+      name,
+      profile: hasProfileData
+        ? {
+            upsert: {
+              create: profileData,
+              update: profileData,
+            },
+          }
+        : undefined,
+    },
+    omit,
+    include: { profile: true },
+  })
 }

--- a/backend/tests/integration/auth/register.spec.ts
+++ b/backend/tests/integration/auth/register.spec.ts
@@ -1,0 +1,63 @@
+import type { z } from '@hono/zod-openapi'
+import type { RegisterSchema } from '@/schemas/auth.schema'
+import { testClient } from 'hono/testing'
+import * as status from 'stoker/http-status-codes'
+import { afterAll, assert, describe, expect, it } from 'vitest'
+import { MOCK_PROFILE, MOCK_USER } from '@/constants/seed.constant'
+import { UserRole } from '@/generated/prisma/enums'
+import { createTestApp } from '@/lib/config'
+import prisma from '@/lib/orm'
+import { auth } from '@/routes'
+
+const client = testClient(createTestApp(auth))
+
+describe('[Auth] Cadastro de usuário', () => {
+  const endpoint = client.auth.register
+
+  const basePayload: z.infer<typeof RegisterSchema> = {
+    ...MOCK_USER,
+    ...MOCK_PROFILE,
+    email: 'aluno.teste@example.com',
+    role: UserRole.ALUNO,
+    birthDate: new Date(MOCK_PROFILE.birthDate),
+  }
+
+  afterAll(async () => {
+    await prisma.user.delete({ where: { email: basePayload.email } }).catch(() => {})
+  })
+
+  it('cadastra um aluno com dados de perfil com sucesso', async () => {
+    const res = await endpoint.$post({ json: basePayload })
+
+    assert(res.status === status.CREATED)
+    const json = await res.json()
+    expect(json).toHaveProperty('id')
+    expect(json).toHaveProperty('email', basePayload.email)
+    expect(json.role).toBe(UserRole.ALUNO)
+    expect(json.profile).toBeDefined()
+  })
+
+  it('deve retornar erro ao tentar cadastrar com e-mail já existente', async () => {
+    const res = await endpoint.$post({ json: basePayload })
+
+    assert(res.status === status.CONFLICT)
+    const json = await res.json()
+
+    expect(json).toHaveProperty('message')
+  })
+
+  it('deve retornar erro ao tentar cadastrar com código de convite inválido', async () => {
+    const payloadConviteInvalido = {
+      ...basePayload,
+      email: 'outro.aluno@example.com',
+      inviteCode: 'CODIGO_INVALIDO_999',
+    }
+
+    const res = await endpoint.$post({ json: payloadConviteInvalido })
+
+    assert(res.status === status.BAD_REQUEST)
+    const json = await res.json()
+
+    expect(json).toHaveProperty('message')
+  })
+})

--- a/backend/tests/integration/me/update-profile-flow.spec.ts
+++ b/backend/tests/integration/me/update-profile-flow.spec.ts
@@ -1,0 +1,127 @@
+import { cpf } from 'cpf-cnpj-validator'
+import { testClient } from 'hono/testing'
+import * as status from 'stoker/http-status-codes'
+import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest'
+import { createTestApp } from '@/lib/config'
+import prisma from '@/lib/orm'
+import { me } from '@/routes'
+import { seedUsers } from '@/seeds'
+import { getAuthHeaders } from '../../util'
+
+const client = testClient(createTestApp(me))
+
+describe('[User Profile Flow] - Atualização de Perfil → Validação de CPF → Bloqueio de Admin', () => {
+  let alunoHeaders: { Authorization: string }
+  let adminHeaders: { Authorization: string }
+
+  const cpfEmUso = cpf.generate()
+
+  beforeAll(async () => {
+    await seedUsers()
+    alunoHeaders = await getAuthHeaders('aluno@test.com', 'ALUNO')
+    adminHeaders = await getAuthHeaders('admin@test.com', 'ADMIN')
+
+    await prisma.user.create({
+      data: {
+        name: 'Aluno do Conflito de CPF',
+        email: 'conflito-cpf@test.com',
+        passwordHash: 'hashed_pass',
+        role: 'ALUNO',
+        profile: { create: { cpf: cpfEmUso } },
+      },
+    })
+  })
+
+  afterAll(async () => {
+    await prisma.user.deleteMany()
+  })
+
+  const patchEndpoint = client.me.$patch
+  const getEndpoint = client.me.$get
+
+  it('[Step 1] Usuário anônimo tenta atualizar perfil e é bloqueado', async () => {
+    const res = await patchEndpoint({ json: { bankName: 'BANCO TESTE' } })
+    expect(res.status).toBe(status.UNAUTHORIZED)
+  })
+
+  it('[Step 2] Aluno atualiza seus dados bancários com sucesso', async () => {
+    const updatePayload = {
+      bankCode: '001',
+      bankName: 'BANCO DO BRASIL',
+      bankAgency: '1234',
+      bankAccount: '56789-0',
+    }
+
+    const res = await patchEndpoint(
+      { json: updatePayload },
+      { headers: alunoHeaders },
+    )
+
+    assert(res.status === status.OK)
+    const json = await res.json()
+
+    assert(json.profile)
+    expect(json.profile.bankCode).toBe(updatePayload.bankCode)
+    expect(json.profile.bankAccount).toBe('****89-0')
+  })
+
+  it('[Step 3] Aluno visualiza o próprio perfil e confirma a persistência dos dados', async () => {
+    const res = await getEndpoint(
+      {},
+      { headers: alunoHeaders },
+    )
+
+    assert(res.status === status.OK)
+    const json = await res.json()
+
+    expect(json.profile).toBeDefined()
+    expect(json.profile?.bankCode).toBe('001')
+    expect(json.profile?.bankName).toBe('BANCO DO BRASIL')
+  })
+
+  it('[Step 4] Aluno tenta atualizar seu perfil usando um CPF que pertence a outro usuário', async () => {
+    const res = await patchEndpoint(
+      { json: { cpf: cpfEmUso } },
+      { headers: alunoHeaders },
+    )
+    expect(res.status).toBe(status.CONFLICT)
+    assert(res.status === status.CONFLICT)
+    const json = await res.json()
+
+    expect(json).toHaveProperty('message')
+    expect(json.message).toContain('já está em uso')
+  })
+
+  it('[Step 5] Admin tenta adicionar dados bancários e é bloqueado pela regra de negócio', async () => {
+    const res = await patchEndpoint(
+      {
+        json: {
+          bankCode: '341',
+          bankName: 'ITAU',
+        },
+      },
+      { headers: adminHeaders },
+    )
+
+    assert(res.status === status.FORBIDDEN)
+    const json = await res.json()
+
+    expect(json).toHaveProperty('message')
+    expect(json.message).toContain('Acesso negado')
+  })
+
+  it('[Step 6] Admin atualiza apenas o próprio nome com sucesso (permitido)', async () => {
+    const newAdminName = 'flamingo admin'
+    const res = await patchEndpoint(
+      { json: { name: newAdminName } },
+      { headers: adminHeaders },
+    )
+
+    expect(res.status).toBe(status.OK)
+    assert(res.status === status.OK)
+    const json = await res.json()
+
+    expect(json.name).toBe(newAdminName)
+    expect(json.profile).toBeNull()
+  })
+})

--- a/backend/tests/schema/register.schema.test.ts
+++ b/backend/tests/schema/register.schema.test.ts
@@ -1,0 +1,119 @@
+import { z } from '@hono/zod-openapi'
+import { assert, describe, expect, it } from 'vitest'
+import { UserRole } from '@/generated/prisma/enums'
+import { RegisterSchema } from '@/schemas/auth.schema'
+
+describe('registerSchema - Validações de Negócio', () => {
+  const validBaseAluno: z.infer<typeof RegisterSchema> = {
+    name: 'Aluno de Teste',
+    email: 'teste@exemplo.com',
+    password: 'P@ssword123',
+    role: UserRole.ALUNO,
+    inviteCode: 'CONVITE2026',
+    cpf: '52998224725',
+    rgPassaporte: 'MG-12.345',
+    birthDate: new Date('1995-05-15T00:00:00Z'),
+    profession: 'Estudante',
+    address: 'Rua Principal, 123',
+    bankCode: '001',
+    bankName: 'Banco do Brasil',
+    bankAgency: '1234-X',
+    bankAccount: '123456',
+  }
+
+  describe('validação de CPF', () => {
+    it('deve rejeitar a ausência de CPF para ALUNO', () => {
+      const { cpf, ...dataWithoutCpf } = validBaseAluno
+      const result = RegisterSchema.safeParse(dataWithoutCpf)
+
+      assert(!result.success)
+      expect(z.treeifyError(result.error).properties).toHaveProperty('cpf')
+    })
+
+    it('deve rejeitar um CPF com todos os números iguais (ex: 111.111.111-11)', () => {
+      const data: z.infer<typeof RegisterSchema> = {
+        ...validBaseAluno,
+        cpf: '11111111111',
+      }
+      const result = RegisterSchema.safeParse(data)
+
+      assert(!result.success)
+      expect(z.treeifyError(result.error).properties).toHaveProperty('cpf')
+    })
+
+    it('deve rejeitar um CPF com cálculo de dígito verificador incorreto', () => {
+      const data: z.infer<typeof RegisterSchema> = {
+        ...validBaseAluno,
+        cpf: '12345678909',
+      }
+      const result = RegisterSchema.safeParse(data)
+
+      assert(!result.success)
+      expect(z.treeifyError(result.error).properties).toHaveProperty('cpf')
+    })
+  })
+
+  describe('validação de Data de Nascimento', () => {
+    it('deve rejeitar usuários com menos de 18 anos (Boundary: 17 anos e 364 dias)', () => {
+      const today = new Date()
+      const underAgeDate = new Date(today.getFullYear() - 18, today.getMonth(), today.getDate() + 1)
+
+      const data: z.infer<typeof RegisterSchema> = {
+        ...validBaseAluno,
+        birthDate: underAgeDate,
+      }
+      const result = RegisterSchema.safeParse(data)
+
+      assert(!result.success)
+      expect(z.treeifyError(result.error).properties).toHaveProperty('birthDate')
+    })
+
+    it('deve aceitar usuários com exatamente 18 anos (Boundary: hoje)', () => {
+      const today = new Date()
+      const exactlyEighteen = new Date(today.getFullYear() - 18, today.getMonth(), today.getDate())
+
+      const data: z.infer<typeof RegisterSchema> = {
+        ...validBaseAluno,
+        birthDate: exactlyEighteen,
+      }
+      const result = RegisterSchema.safeParse(data)
+
+      assert(result.success)
+    })
+
+    it('deve rejeitar datas absurdas no passado (Boundary: > 120 anos)', () => {
+      const today = new Date()
+      const tooOldDate = new Date(today.getFullYear() - 120, today.getMonth(), today.getDate() - 1)
+
+      const data: z.infer<typeof RegisterSchema> = {
+        ...validBaseAluno,
+        birthDate: tooOldDate,
+      }
+      const result = RegisterSchema.safeParse(data)
+
+      assert(!result.success)
+      expect(z.treeifyError(result.error).properties).toHaveProperty('birthDate')
+    })
+  })
+
+  describe('validações Bancárias', () => {
+    it('deve rejeitar código de banco com letras ou diferente de 3 dígitos', () => {
+      const data1: z.infer<typeof RegisterSchema> = {
+        ...validBaseAluno,
+        bankCode: '01',
+      }
+      const data2: z.infer<typeof RegisterSchema> = {
+        ...validBaseAluno,
+        bankCode: '01A',
+      }
+
+      const result1 = RegisterSchema.safeParse(data1)
+      const result2 = RegisterSchema.safeParse(data2)
+
+      assert(!result1.success)
+      assert(!result2.success)
+      expect(z.treeifyError(result1.error).properties).toHaveProperty('bankCode')
+      expect(z.treeifyError(result2.error).properties).toHaveProperty('bankCode')
+    })
+  })
+})

--- a/backend/tests/schema/user.schema.test.ts
+++ b/backend/tests/schema/user.schema.test.ts
@@ -14,7 +14,7 @@ describe('userSchema - validações', () => {
   }
 
   describe('mascaramento de conta bancária', () => {
-    it('deve mascarar os últimos 4 dígitos de uma conta longa', () => {
+    it('deve mascarar os primeiros 4 dígitos de uma conta longa', () => {
       const data = {
         ...validUser,
         profile: { bankAccount: '12345678' },
@@ -23,7 +23,7 @@ describe('userSchema - validações', () => {
       const result = UserSchema.safeParse(data)
       expect(result.success)
       assert(result.data)
-      expect(result.data.profile?.bankAccount).toBe('1234****')
+      expect(result.data.profile?.bankAccount).toBe('****5678')
     })
 
     it('deve retornar **** se a conta tiver 4 ou menos caracteres', () => {

--- a/backend/tests/schema/user.schema.test.ts
+++ b/backend/tests/schema/user.schema.test.ts
@@ -1,0 +1,41 @@
+import { assert, describe, expect, it } from 'vitest'
+import { UserRole } from '@/generated/prisma/enums'
+import { UserSchema } from '@/schemas/user.schema'
+
+describe('userSchema - validações', () => {
+  const validUser = {
+    id: '00000000-0000-0000-0000-000000000000',
+    name: 'Teste',
+    email: 'teste@exemplo.com',
+    role: UserRole.ALUNO,
+    isActive: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+
+  describe('mascaramento de conta bancária', () => {
+    it('deve mascarar os últimos 4 dígitos de uma conta longa', () => {
+      const data = {
+        ...validUser,
+        profile: { bankAccount: '12345678' },
+      }
+
+      const result = UserSchema.safeParse(data)
+      expect(result.success)
+      assert(result.data)
+      expect(result.data.profile?.bankAccount).toBe('1234****')
+    })
+
+    it('deve retornar **** se a conta tiver 4 ou menos caracteres', () => {
+      const data = {
+        ...validUser,
+        profile: { bankAccount: '123' },
+      }
+
+      const result = UserSchema.safeParse(data)
+      expect(result.success)
+      assert(result.data)
+      expect(result.data.profile?.bankAccount).toBe('****')
+    })
+  })
+})

--- a/testes/backend/package-lock.json
+++ b/testes/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@prisma/adapter-pg": "^7.6.0",
         "@prisma/client": "^7.6.0",
         "bcryptjs": "^3.0.3",
+        "cpf-cnpj-validator": "^2.1.0",
         "dotenv": "^17.4.0",
         "dotenv-expand": "^12.0.3",
         "hono": "^4.12.9",
@@ -802,6 +803,43 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cpf-cnpj-validator": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cpf-cnpj-validator/-/cpf-cnpj-validator-2.1.0.tgz",
+      "integrity": "sha512-tgSVKy8EK8LMRYRtoTfPICQ5innN0go/aqokEAF66HW466MHDsjBGkyPOY0KmCJ+k7Jh0CG9m70YHp30yiOCLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@angular/forms": ">=15",
+        "class-validator": "^0.14.0 || ^0.15.0",
+        "joi": "^17.0.0",
+        "reflect-metadata": "^0.2.0",
+        "yup": "^1.0.0",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/forms": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        },
+        "joi": {
+          "optional": true
+        },
+        "reflect-metadata": {
+          "optional": true
+        },
+        "yup": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1717,7 +1755,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/testes/backend/package.json
+++ b/testes/backend/package.json
@@ -12,6 +12,7 @@
     "@prisma/adapter-pg": "^7.6.0",
     "@prisma/client": "^7.6.0",
     "bcryptjs": "^3.0.3",
+    "cpf-cnpj-validator": "^2.1.0",
     "dotenv": "^17.4.0",
     "dotenv-expand": "^12.0.3",
     "hono": "^4.12.9",


### PR DESCRIPTION
## Why is this PR necessary, what does it do?
   * Exigir que usuários com a role ALUNO forneçam dados bancários, endereço, CPF entre outros no ato do registro.
   * Permite que usuários atualizem suas informações.
     * Dados sensíveis para `ALUNO`
     * Apenas `name` para `Coordenador` e `ADMIN`

   * Adiciona testes de integração para validação de fluxo.

  Endpoints afetados:
   * POST /auth/register
   * PATCH /me 
   * GET /me 

  ## References
   * [Validação de CPF:](https://www.npmjs.com/package/cpf-cnpj-validator)


  ## Notes
   * Contribuição com testes: 
       * backend/tests/integration/me/update-profile-flow.spec.ts
       * backend/tests/integration/auth/register.spec.ts
   * Escopo: O campo recoveryEmail foi postergado a fim de reduzir a complexidade e agilizar a revisão deste incremento.
   * Se aprovado, pode habilitar as seguintes tarefas de teste: 
       * #170 
       * #167
