### PR TITLE
Feat/backend/invite code

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "bcryptjs": "^3.0.3",
         "cpf-cnpj-validator": "^2.1.0",
         "cross-env": "^10.1.0",
+        "dayjs": "^1.11.20",
         "dotenv": "^17.4.0",
         "dotenv-expand": "^12.0.3",
         "hono": "^4.12.9",
@@ -6066,6 +6067,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "bcryptjs": "^3.0.3",
     "cpf-cnpj-validator": "^2.1.0",
     "cross-env": "^10.1.0",
+    "dayjs": "^1.11.20",
     "dotenv": "^17.4.0",
     "dotenv-expand": "^12.0.3",
     "hono": "^4.12.9",

--- a/backend/prisma/migrations/20260510020857_add_invite_code/migration.sql
+++ b/backend/prisma/migrations/20260510020857_add_invite_code/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "InviteCode" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "role" "UserRole" NOT NULL,
+    "usedById" TEXT,
+    "usedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "InviteCode_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InviteCode_code_key" ON "InviteCode"("code");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -117,3 +117,13 @@ model CostBreakdown {
   createdAt         DateTime        @default(now())
   updatedAt         DateTime        @updatedAt
 }
+
+model InviteCode {
+  id        String    @id @default(uuid())
+  code      String    @unique
+  role      UserRole
+  usedById  String?
+  usedAt    DateTime?
+  expiresAt DateTime
+  createdAt DateTime  @default(now())
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,6 @@
 import { configureDocs, createApp } from './lib/config'
 import { createRouter, registerRoutes } from './lib/util'
-import { analytics, auth, expenses, health, me, projects } from './routes'
+import { admin, analytics, auth, expenses, health, me, projects } from './routes'
 
 const app = createApp()
 
@@ -13,6 +13,7 @@ registerRoutes(v1, [
   expenses,
   projects,
   analytics,
+  admin,
 ])
 
 app.route('/v1', v1)

--- a/backend/src/constants/invite.constant.ts
+++ b/backend/src/constants/invite.constant.ts
@@ -6,6 +6,11 @@ export const INVITE_STATUS = {
 
 export type InviteStatus = typeof INVITE_STATUS[keyof typeof INVITE_STATUS]
 
+export const INVITE_ERRORS = {
+  ALREADY_USED: 'ALREADY_USED',
+  ALREADY_EXPIRED: 'ALREADY_EXPIRED',
+} as const
+
 export const INVITE_EXPIRY = {
   DEFAULT_HOURS: 24,
   MIN_MINUTES: 10,

--- a/backend/src/constants/invite.constant.ts
+++ b/backend/src/constants/invite.constant.ts
@@ -1,0 +1,14 @@
+export const INVITE_STATUS = {
+  ACTIVE: 'ATIVO',
+  USED: 'USADO',
+  EXPIRED: 'EXPIRADO',
+} as const
+
+export type InviteStatus = typeof INVITE_STATUS[keyof typeof INVITE_STATUS]
+
+export const INVITE_EXPIRY = {
+  DEFAULT_HOURS: 24,
+  MIN_MINUTES: 10,
+} as const
+
+export const mockInviteCode = 'CONVITE2026'

--- a/backend/src/constants/invite.constant.ts
+++ b/backend/src/constants/invite.constant.ts
@@ -13,7 +13,7 @@ export const INVITE_ERRORS = {
 
 export const INVITE_EXPIRY = {
   DEFAULT_HOURS: 24,
-  MIN_MINUTES: 10,
+  MIN_MINUTES: 30,
 } as const
 
 export const mockInviteCode = 'CONVITE2026'

--- a/backend/src/constants/seed.constant.ts
+++ b/backend/src/constants/seed.constant.ts
@@ -23,7 +23,7 @@ const MOCK_USER = {
   name: 'João Silva',
   email: 'usuario@exemplo.com',
   password: 'P@ssw0rd123',
-  inviteCode: 'CONVITE2026',
+  inviteCode: 'aluno2026',
 } as const
 
 export {

--- a/backend/src/lib/date.ts
+++ b/backend/src/lib/date.ts
@@ -1,6 +1,10 @@
 import dayjs from 'dayjs'
+import localizedFormat from 'dayjs/plugin/localizedFormat.js'
+import utc from 'dayjs/plugin/utc.js'
 import 'dayjs/locale/pt-br.js'
 
+dayjs.extend(utc)
+dayjs.extend(localizedFormat)
 dayjs.locale('pt-br')
 
 export { dayjs }

--- a/backend/src/lib/date.ts
+++ b/backend/src/lib/date.ts
@@ -1,0 +1,6 @@
+import dayjs from 'dayjs'
+import 'dayjs/locale/pt-br.js'
+
+dayjs.locale('pt-br')
+
+export { dayjs }

--- a/backend/src/routes/admin/index.ts
+++ b/backend/src/routes/admin/index.ts
@@ -1,0 +1,7 @@
+import { createRouter } from '@/lib/util'
+import invites from './invites'
+
+const router = createRouter().basePath('/admin')
+  .route('/', invites)
+
+export default router

--- a/backend/src/routes/admin/invites/index.ts
+++ b/backend/src/routes/admin/invites/index.ts
@@ -1,0 +1,10 @@
+import { createRouter } from '@/lib/util'
+import * as handlers from './invites.handler'
+import * as routes from './invites.route'
+
+const router = createRouter().basePath('/invites')
+  .openapi(routes.index, handlers.index)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.remove, handlers.remove)
+
+export default router

--- a/backend/src/routes/admin/invites/invites.handler.ts
+++ b/backend/src/routes/admin/invites/invites.handler.ts
@@ -2,6 +2,7 @@ import type { CreateRoute, IndexRoute, RemoveRoute } from './invites.route'
 import type { AppRouteHandler } from '@/lib/type'
 import * as codes from 'stoker/http-status-codes'
 import * as phrases from 'stoker/http-status-phrases'
+import { INVITE_ERRORS } from '@/constants/invite.constant'
 import { InviteResponseSchema, ListInvitesSchema } from '@/schemas/admin.invite.schema'
 import { createInvite, getInviteDefaultExpiry, listInvites, mapInviteStatus, revokeInvite } from '@/services/invite.service'
 
@@ -29,8 +30,15 @@ export const remove: AppRouteHandler<RemoveRoute> = async (c) => {
   const result = await revokeInvite(id)
 
   if (result && 'error' in result) {
-    if (result.error === phrases.NOT_FOUND) {
-      return c.json({ message: 'Convite não encontrado' }, codes.NOT_FOUND)
+    switch (result.error) {
+      case phrases.NOT_FOUND:
+        return c.json({ message: 'Convite não encontrado' }, codes.NOT_FOUND)
+      case INVITE_ERRORS.ALREADY_USED:
+        return c.json({ message: 'Não é possível revogar um convite que já foi utilizado' }, codes.CONFLICT)
+      case INVITE_ERRORS.ALREADY_EXPIRED:
+        return c.json({ message: 'Este convite já está expirado' }, codes.CONFLICT)
+      default:
+        return c.json({ message: phrases.INTERNAL_SERVER_ERROR }, codes.INTERNAL_SERVER_ERROR)
     }
   }
 

--- a/backend/src/routes/admin/invites/invites.handler.ts
+++ b/backend/src/routes/admin/invites/invites.handler.ts
@@ -1,0 +1,38 @@
+import type { CreateRoute, IndexRoute, RemoveRoute } from './invites.route'
+import type { AppRouteHandler } from '@/lib/type'
+import * as codes from 'stoker/http-status-codes'
+import * as phrases from 'stoker/http-status-phrases'
+import { InviteResponseSchema, ListInvitesSchema } from '@/schemas/admin.invite.schema'
+import { createInvite, getInviteDefaultExpiry, listInvites, mapInviteStatus, revokeInvite } from '@/services/invite.service'
+
+export const index: AppRouteHandler<IndexRoute> = async (c) => {
+  const query = c.req.valid('query')
+  const invites = await listInvites(query)
+  const parsed = ListInvitesSchema.parse(invites)
+  return c.json(parsed, codes.OK)
+}
+
+export const create: AppRouteHandler<CreateRoute> = async (c) => {
+  const { role, expiresAt } = c.req.valid('json')
+  const invite = await createInvite(role, expiresAt || getInviteDefaultExpiry())
+  const status = mapInviteStatus(invite)
+
+  const parsed = InviteResponseSchema.parse({
+    ...invite,
+    status,
+  })
+  return c.json(parsed, codes.CREATED)
+}
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c) => {
+  const { id } = c.req.valid('param')
+  const result = await revokeInvite(id)
+
+  if (result && 'error' in result) {
+    if (result.error === phrases.NOT_FOUND) {
+      return c.json({ message: 'Convite não encontrado' }, codes.NOT_FOUND)
+    }
+  }
+
+  return c.body(null, codes.NO_CONTENT)
+}

--- a/backend/src/routes/admin/invites/invites.route.ts
+++ b/backend/src/routes/admin/invites/invites.route.ts
@@ -1,0 +1,68 @@
+import { createRoute, z } from '@hono/zod-openapi'
+import * as codes from 'stoker/http-status-codes'
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers'
+import { createMessageObjectSchema } from 'stoker/openapi/schemas'
+import { UserRole } from '@/generated/prisma/enums'
+import { requireAuth, requireRole } from '@/middlewares'
+
+import { CreateInviteSchema, InviteResponseSchema, ListInvitesQuerySchema, ListInvitesSchema } from '@/schemas/admin.invite.schema'
+import { ForbiddenResponse, IdSchema, UnauthorizedResponse } from '@/schemas/shared.schema'
+
+const tags = ['Invites']
+const middleware = [requireAuth, requireRole([UserRole.ADMIN])]
+
+export type IndexRoute = typeof index
+export type CreateRoute = typeof create
+export type RemoveRoute = typeof remove
+
+export const index = createRoute({
+  path: '/',
+  method: 'get',
+  middleware,
+  security: [{ bearerAuth: [] }],
+  summary: 'List all invites',
+  description: 'Retorna a lista de todos os códigos de convite gerados, com seus status (ATIVO, USADO, EXPIRADO).',
+  tags,
+  request: { query: ListInvitesQuerySchema },
+  responses: {
+    [codes.OK]: jsonContent(ListInvitesSchema, 'Lista de convites retornada com sucesso.'),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+    [codes.FORBIDDEN]: ForbiddenResponse,
+  },
+})
+
+export const create = createRoute({
+  path: '/',
+  method: 'post',
+  middleware,
+  security: [{ bearerAuth: [] }],
+  summary: 'Create a new invite code',
+  description: 'Gera um novo código de convite aleatório para uma role específica.',
+  tags,
+  request: { body: jsonContentRequired(CreateInviteSchema, 'Dados do convite') },
+  responses: {
+    [codes.CREATED]: jsonContent(InviteResponseSchema, 'Convite criado com sucesso.'),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+    [codes.FORBIDDEN]: ForbiddenResponse,
+  },
+})
+
+export const remove = createRoute({
+  path: '/{id}',
+  method: 'delete',
+  middleware,
+  security: [{ bearerAuth: [] }],
+  summary: 'Revoke an invite code',
+  description: 'Invalida um código de convite (soft: define expiresAt para agora).',
+  tags,
+  request: { params: z.object({ id: IdSchema }) },
+  responses: {
+    [codes.NO_CONTENT]: { description: 'Convite revogado com sucesso.' },
+    [codes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Convite não encontrado'),
+      'Nenhum convite foi localizado com o ID informado.',
+    ),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+    [codes.FORBIDDEN]: ForbiddenResponse,
+  },
+})

--- a/backend/src/routes/admin/invites/invites.route.ts
+++ b/backend/src/routes/admin/invites/invites.route.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from '@hono/zod-openapi'
 import * as codes from 'stoker/http-status-codes'
 import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers'
 import { createMessageObjectSchema } from 'stoker/openapi/schemas'
+import { INVITE_EXPIRY } from '@/constants/invite.constant'
 import { UserRole } from '@/generated/prisma/enums'
 import { requireAuth, requireRole } from '@/middlewares'
 
@@ -37,11 +38,15 @@ export const create = createRoute({
   middleware,
   security: [{ bearerAuth: [] }],
   summary: 'Create a new invite code',
-  description: 'Gera um novo código de convite aleatório para uma role específica.',
+  description: `Gera um novo código de convite aleatório para uma role específica. Se não informada, a expiração padrão é de ${INVITE_EXPIRY.DEFAULT_HOURS} horas. A data de expiração deve ser no mínimo ${INVITE_EXPIRY.MIN_MINUTES} minutos após o momento da criação e deve seguir o padrão UTC.`,
   tags,
   request: { body: jsonContentRequired(CreateInviteSchema, 'Dados do convite') },
   responses: {
     [codes.CREATED]: jsonContent(InviteResponseSchema, 'Convite criado com sucesso.'),
+    [codes.BAD_REQUEST]: jsonContent(
+      createMessageObjectSchema('Dados inválidos'),
+      `Erro de validação (ex: data de expiração inferior ao mínimo de ${INVITE_EXPIRY.MIN_MINUTES} minutos).`,
+    ),
     [codes.UNAUTHORIZED]: UnauthorizedResponse,
     [codes.FORBIDDEN]: ForbiddenResponse,
   },

--- a/backend/src/routes/admin/invites/invites.route.ts
+++ b/backend/src/routes/admin/invites/invites.route.ts
@@ -62,6 +62,10 @@ export const remove = createRoute({
       createMessageObjectSchema('Convite não encontrado'),
       'Nenhum convite foi localizado com o ID informado.',
     ),
+    [codes.CONFLICT]: jsonContent(
+      createMessageObjectSchema('Regra de negócio violada'),
+      'O convite não pode ser revogado (ex: já foi usado ou está expirado).',
+    ),
     [codes.UNAUTHORIZED]: UnauthorizedResponse,
     [codes.FORBIDDEN]: ForbiddenResponse,
   },

--- a/backend/src/routes/auth/auth.handler.ts
+++ b/backend/src/routes/auth/auth.handler.ts
@@ -2,25 +2,43 @@ import type { LoginRoute, RegisterRoute } from './auth.route'
 import type { AppRouteHandler } from '@/lib/type'
 import * as codes from 'stoker/http-status-codes'
 import env from '@/env'
-import { generateAccessToken, isInviteCodeValid, verifyCredentials } from '@/services/auth.service'
+import prisma from '@/lib/orm'
+import { generateAccessToken, verifyCredentials } from '@/services/auth.service'
+import { findActiveInvite, validateAndConsume } from '@/services/invite.service'
 import { createUser, getUserByEmail } from '@/services/user.service'
 
 export const register: AppRouteHandler<RegisterRoute> = async (c) => {
   const data = c.req.valid('json')
 
-  if (!isInviteCodeValid(data.inviteCode)) {
-    return c.json({ message: 'Código de convite inválido' }, codes.BAD_REQUEST)
-  }
-
   const existingUser = await getUserByEmail(data.email)
-
   if (existingUser) {
     return c.json({ message: 'E-mail já cadastrado' }, codes.CONFLICT)
   }
 
-  const user = await createUser(data, env.SALT_ROUNDS)
+  const result = await prisma.$transaction(async (tx) => {
+    const invite = await findActiveInvite(data.inviteCode, tx)
+    if (!invite) {
+      return { error: 'Código de convite inválido ou expirado' }
+    }
 
-  return c.json(user, codes.CREATED)
+    const newUser = await createUser({
+      ...data,
+      role: invite.role,
+    }, env.SALT_ROUNDS, tx)
+
+    const consumeResult = await validateAndConsume(data.inviteCode, newUser.id, tx)
+    if ('error' in consumeResult) {
+      return consumeResult
+    }
+
+    return { data: newUser }
+  })
+
+  if ('error' in result) {
+    return c.json({ message: result.error || 'Código de convite inválido ou expirado' }, codes.BAD_REQUEST)
+  }
+
+  return c.json(result.data, codes.CREATED)
 }
 
 export const login: AppRouteHandler<LoginRoute> = async (c) => {

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,3 +1,4 @@
+export { default as admin } from './admin'
 export { default as analytics } from './analytics'
 export { default as auth } from './auth'
 export { default as expenses } from './expenses'

--- a/backend/src/schemas/admin.invite.schema.ts
+++ b/backend/src/schemas/admin.invite.schema.ts
@@ -1,0 +1,42 @@
+import { z } from '@hono/zod-openapi'
+import { INVITE_STATUS, mockInviteCode } from '@/constants/invite.constant'
+import { UserRole } from '@/generated/prisma/enums'
+import { minExpiryThresholdCheck, usedInviteFieldsRequired } from '@/schemas/schema.refine'
+import { getInviteDefaultExpiry, getInviteExampleExpiry } from '@/services/invite.service'
+import { IdSchema, TimestampSchema } from './shared.schema'
+
+const BaseSchema = z.object({
+  id: IdSchema,
+  code: z.string().openapi({ example: mockInviteCode }),
+  role: z.enum(UserRole).openapi({ example: UserRole.ALUNO }),
+  usedById: IdSchema.nullish().default(null),
+  usedAt: z.coerce.date()
+    .nullable()
+    .openapi({ example: null })
+    .default(null),
+  expiresAt: z.coerce.date().default(getInviteDefaultExpiry())
+    .openapi({ example: getInviteExampleExpiry() }),
+  status: z.enum([INVITE_STATUS.ACTIVE, INVITE_STATUS.USED, INVITE_STATUS.EXPIRED]).openapi({ example: INVITE_STATUS.ACTIVE }),
+  createdAt: TimestampSchema.createdAt,
+})
+
+export const CreateInviteSchema = BaseSchema.pick({
+  role: true,
+  expiresAt: true,
+}).superRefine(minExpiryThresholdCheck())
+
+export const ListInvitesQuerySchema = BaseSchema.pick({
+  role: true,
+  status: true,
+}).extend({
+  search: z.string().optional()
+    .openapi({
+      description: 'Busca pelo código de convite',
+      example: mockInviteCode,
+    }),
+})
+  .partial()
+
+export const InviteResponseSchema = BaseSchema.check(usedInviteFieldsRequired)
+
+export const ListInvitesSchema = z.array(InviteResponseSchema)

--- a/backend/src/schemas/admin.invite.schema.ts
+++ b/backend/src/schemas/admin.invite.schema.ts
@@ -15,7 +15,10 @@ const BaseSchema = z.object({
     .openapi({ example: null })
     .default(null),
   expiresAt: z.coerce.date().default(getInviteDefaultExpiry())
-    .openapi({ example: getInviteExampleExpiry() }),
+    .openapi({
+      description: 'Data e hora de expiração do convite. Segue o padrão UTC (ISO 8601).',
+      example: getInviteExampleExpiry(),
+    }),
   status: z.enum([INVITE_STATUS.ACTIVE, INVITE_STATUS.USED, INVITE_STATUS.EXPIRED]).openapi({ example: INVITE_STATUS.ACTIVE }),
   createdAt: TimestampSchema.createdAt,
 })

--- a/backend/src/schemas/schema.refine.ts
+++ b/backend/src/schemas/schema.refine.ts
@@ -104,8 +104,8 @@ export function minExpiryThresholdCheck() {
     const minExpiry = getInviteMinExpiry()
 
     if (value.expiresAt && !dayjs(value.expiresAt).isAfter(minExpiry)) {
-      const dataFormatada = dayjs(value.expiresAt).format('LLL')
-      const limiteFormatado = dayjs(minExpiry).format('LT')
+      const dataFormatada = dayjs.utc(value.expiresAt).format('LT')
+      const limiteFormatado = dayjs.utc(minExpiry).format('LT')
 
       ctx.addIssue({
         code: 'custom',

--- a/backend/src/schemas/schema.refine.ts
+++ b/backend/src/schemas/schema.refine.ts
@@ -103,13 +103,13 @@ export function minExpiryThresholdCheck() {
   return (value: { expiresAt?: Date }, ctx: z.RefinementCtx) => {
     const minExpiry = getInviteMinExpiry()
 
-    if (value.expiresAt && !dayjs(value.expiresAt).isAfter(minExpiry)) {
+    if (value.expiresAt && dayjs(value.expiresAt).isBefore(minExpiry)) {
       const dataFormatada = dayjs.utc(value.expiresAt).format('LT')
       const limiteFormatado = dayjs.utc(minExpiry).format('LT')
 
       ctx.addIssue({
         code: 'custom',
-        message: `A data (${dataFormatada}) é inválida. O mínimo aceitável é às ${limiteFormatado}.`,
+        message: `A data ${dataFormatada} é inválida. O mínimo aceitável é às ${limiteFormatado}.`,
         path: ['expiresAt'],
       })
     }

--- a/backend/src/schemas/schema.refine.ts
+++ b/backend/src/schemas/schema.refine.ts
@@ -1,9 +1,13 @@
+import type { InviteStatus } from '@/constants/invite.constant'
 import type { ExpenseRequestStatus } from '@/generated/prisma/enums'
 import { z } from '@hono/zod-openapi'
 import countries from 'i18n-iso-countries'
 import iso31662 from 'iso-3166-2'
 import { STATUSES_WHERE_REASON_REQUIRED } from '@/constants/expense.constant'
+import { INVITE_STATUS } from '@/constants/invite.constant'
+import { dayjs } from '@/lib/date'
 import { validatePDF } from '@/lib/storage'
+import { getInviteMinExpiry } from '@/services/invite.service'
 
 export const validStateCheck = z.refine<{ state: string }>(
   value => iso31662.subdivision(value.state) !== null,
@@ -95,3 +99,36 @@ export const validBankCode = z.string().superRefine((val, ctx) => {
     })
   }
 })
+export function minExpiryThresholdCheck() {
+  return (value: { expiresAt?: Date }, ctx: z.RefinementCtx) => {
+    const minExpiry = getInviteMinExpiry()
+
+    if (value.expiresAt && !dayjs(value.expiresAt).isAfter(minExpiry)) {
+      const dataFormatada = dayjs(value.expiresAt).format('LLL')
+      const limiteFormatado = dayjs(minExpiry).format('LT')
+
+      ctx.addIssue({
+        code: 'custom',
+        message: `A data (${dataFormatada}) é inválida. O mínimo aceitável é às ${limiteFormatado}.`,
+        path: ['expiresAt'],
+      })
+    }
+  }
+}
+
+export const usedInviteFieldsRequired = z.refine<{
+  status: InviteStatus
+  usedById?: string | null
+  usedAt?: Date | null
+}>(
+  (value) => {
+    if (value.status !== INVITE_STATUS.USED)
+      return true
+
+    return !!value.usedById && !!value.usedAt
+  },
+  {
+    message: 'Dados de utilização (quem e quando) são obrigatórios para convites usados',
+    path: ['status'],
+  },
+)

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -1,8 +1,9 @@
 import prisma from './lib/orm'
-import { seedExpenseCategories, seedExpenses, seedProjects, seedUsers } from './seeds'
+import { seedExpenseCategories, seedExpenses, seedInviteCodes, seedProjects, seedUsers } from './seeds'
 
 async function main() {
   await seedExpenseCategories()
+  await seedInviteCodes()
   await seedProjects()
   await seedUsers()
   await seedExpenses()

--- a/backend/src/seeds/index.ts
+++ b/backend/src/seeds/index.ts
@@ -1,4 +1,5 @@
 export { default as seedExpenseCategories } from './expense.category.seed'
 export { default as seedExpenses } from './expense.seed'
+export { default as seedInviteCodes } from './invite-code.seed'
 export { default as seedProjects } from './project.seed'
 export { default as seedUsers } from './user.seed'

--- a/backend/src/seeds/invite-code.seed.ts
+++ b/backend/src/seeds/invite-code.seed.ts
@@ -1,0 +1,44 @@
+/* eslint-disable no-console */
+import type { Prisma } from '@/generated/prisma/client'
+import { UserRole } from '@/generated/prisma/client'
+import prisma from '@/lib/orm'
+import { getInviteDefaultExpiry } from '@/services/invite.service'
+
+export const dummyInviteCodes = [
+  {
+    code: 'aluno2026',
+    role: UserRole.ALUNO,
+    expiresAt: getInviteDefaultExpiry(),
+  },
+  {
+    code: 'coordenador2026',
+    role: UserRole.COORDENADOR,
+    expiresAt: getInviteDefaultExpiry(),
+  },
+  {
+    code: 'admin2026',
+    role: UserRole.ADMIN,
+    expiresAt: getInviteDefaultExpiry(),
+  },
+] satisfies Prisma.InviteCodeCreateInput[]
+
+async function seedInviteCodes() {
+  console.log('🎫 Seeding Invite Codes...')
+
+  for (const data of dummyInviteCodes) {
+    const expiresAt = getInviteDefaultExpiry()
+    await prisma.inviteCode.upsert({
+      where: { code: data.code },
+      update: {
+        role: data.role,
+        expiresAt,
+      },
+      create: {
+        ...data,
+        expiresAt,
+      },
+    })
+  }
+}
+
+export default seedInviteCodes

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,13 +1,13 @@
-import type { z } from 'zod'
+import type { z } from '@hono/zod-openapi'
 import type { AppAuthPayload } from '@/lib/type'
 import type { LoginSchema } from '@/schemas/auth.schema'
 import { compare } from 'bcryptjs'
 import { sign } from 'hono/jwt'
+import { mockInviteCode } from '@/constants/invite.constant'
 import env from '@/env'
 import { getUserByEmail } from './user.service'
 
-export const mockInviteCode = 'CONVITE2026'
-
+/** @deprecated Use findActiveInvite from invite.service instead for real database validation */
 export function isInviteCodeValid(inviteCode: string): boolean {
   return inviteCode === mockInviteCode
 }

--- a/backend/src/services/invite.service.ts
+++ b/backend/src/services/invite.service.ts
@@ -4,7 +4,7 @@ import type { InviteCode, Prisma, UserRole } from '@/generated/prisma/client'
 import type { ListInvitesQuerySchema } from '@/schemas/admin.invite.schema'
 import crypto from 'node:crypto'
 import * as phrases from 'stoker/http-status-phrases'
-import { INVITE_EXPIRY, INVITE_STATUS } from '@/constants/invite.constant'
+import { INVITE_ERRORS, INVITE_EXPIRY, INVITE_STATUS } from '@/constants/invite.constant'
 import { dayjs } from '@/lib/date'
 import prisma from '@/lib/orm'
 
@@ -90,6 +90,14 @@ export async function revokeInvite(id: string): Promise<InviteCode | { error: st
   const invite = await prisma.inviteCode.findUnique({ where: { id } })
   if (!invite) {
     return { error: phrases.NOT_FOUND }
+  }
+
+  if (invite.usedById) {
+    return { error: INVITE_ERRORS.ALREADY_USED }
+  }
+
+  if (dayjs().isAfter(invite.expiresAt)) {
+    return { error: INVITE_ERRORS.ALREADY_EXPIRED }
   }
 
   return prisma.inviteCode.update({

--- a/backend/src/services/invite.service.ts
+++ b/backend/src/services/invite.service.ts
@@ -1,0 +1,124 @@
+import type { z } from '@hono/zod-openapi'
+import type { InviteStatus } from '@/constants/invite.constant'
+import type { InviteCode, Prisma, UserRole } from '@/generated/prisma/client'
+import type { ListInvitesQuerySchema } from '@/schemas/admin.invite.schema'
+import crypto from 'node:crypto'
+import * as phrases from 'stoker/http-status-phrases'
+import { INVITE_EXPIRY, INVITE_STATUS } from '@/constants/invite.constant'
+import { dayjs } from '@/lib/date'
+import prisma from '@/lib/orm'
+
+export function mapInviteStatus(invite: InviteCode): InviteStatus {
+  if (invite.usedById)
+    return INVITE_STATUS.USED
+  if (dayjs().isAfter(invite.expiresAt))
+    return INVITE_STATUS.EXPIRED
+  return INVITE_STATUS.ACTIVE
+}
+
+export function getInviteDefaultExpiry() {
+  return dayjs().add(INVITE_EXPIRY.DEFAULT_HOURS, 'hours')
+    .toDate()
+}
+
+export function getInviteMinExpiry() {
+  return dayjs().add(INVITE_EXPIRY.MIN_MINUTES, 'minutes')
+    .toDate()
+}
+
+export function getInviteExampleExpiry() {
+  return dayjs().add(INVITE_EXPIRY.MIN_MINUTES, 'minutes')
+    .toISOString()
+}
+
+function generateRandomCode(bytes: number = 4): string {
+  return crypto.randomBytes(bytes).toString('hex')
+    .toUpperCase()
+}
+
+export async function createInvite(role: UserRole, expiresAt?: Date) {
+  const code = generateRandomCode()
+
+  return prisma.inviteCode.create({
+    data: {
+      code,
+      role,
+      expiresAt: expiresAt ?? getInviteDefaultExpiry(),
+    },
+  })
+}
+
+export async function listInvites(filters: z.infer<typeof ListInvitesQuerySchema>) {
+  const { role, status, search } = filters
+
+  const where: Prisma.InviteCodeWhereInput = {
+    role,
+    code: {
+      contains: search,
+      mode: 'insensitive',
+    },
+  }
+
+  switch (status) {
+    case INVITE_STATUS.USED:
+      where.usedById = { not: null }
+      break
+
+    case INVITE_STATUS.EXPIRED:
+      where.usedById = null
+      where.expiresAt = { lt: dayjs().toDate() }
+      break
+
+    case INVITE_STATUS.ACTIVE:
+      where.usedById = null
+      where.expiresAt = { gt: dayjs().toDate() }
+      break
+  }
+
+  const invites = await prisma.inviteCode.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return invites.map(invite => ({
+    ...invite,
+    status: mapInviteStatus(invite),
+  }))
+}
+
+export async function revokeInvite(id: string): Promise<InviteCode | { error: string }> {
+  const invite = await prisma.inviteCode.findUnique({ where: { id } })
+  if (!invite) {
+    return { error: phrases.NOT_FOUND }
+  }
+
+  return prisma.inviteCode.update({
+    where: { id },
+    data: { expiresAt: dayjs().toDate() },
+  })
+}
+
+export async function findActiveInvite(code: string, tx: Prisma.TransactionClient = prisma) {
+  const invite = await tx.inviteCode.findUnique({ where: { code } })
+
+  if (!invite || mapInviteStatus(invite) !== INVITE_STATUS.ACTIVE) {
+    return null
+  }
+
+  return invite
+}
+
+export async function validateAndConsume(code: string, userId: string, tx: Prisma.TransactionClient = prisma): Promise<InviteCode | { error: string }> {
+  const invite = await findActiveInvite(code, tx)
+  if (!invite) {
+    return { error: 'Convite inválido, já utilizado ou expirado.' }
+  }
+
+  return tx.inviteCode.update({
+    where: { id: invite.id },
+    data: {
+      usedById: userId,
+      usedAt: dayjs().toDate(),
+    },
+  })
+}

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,4 +1,5 @@
 import type { z } from '@hono/zod-openapi'
+import type { Prisma } from '@/generated/prisma/client'
 import type { ProfileCreateWithoutUserInput } from '@/generated/prisma/models'
 import type { RegisterSchema } from '@/schemas/auth.schema'
 import type { UpdateProfileSchema } from '@/schemas/user.schema'
@@ -12,7 +13,7 @@ const omit = { passwordHash: true }
 type CreateUserDTO = z.infer<typeof RegisterSchema>
 type UpdateUserDTO = z.infer<typeof UpdateProfileSchema>
 
-export async function createUser(data: CreateUserDTO, saltRounds: number) {
+export async function createUser(data: CreateUserDTO, saltRounds: number, tx: Prisma.TransactionClient = prisma) {
   const { name, email, role, password, inviteCode: _ } = data
 
   const salt = await bcrypt.genSalt(saltRounds)
@@ -32,7 +33,7 @@ export async function createUser(data: CreateUserDTO, saltRounds: number) {
       }
     : undefined
 
-  return prisma.user.create({
+  return tx.user.create({
     data: {
       name,
       email,

--- a/backend/tests/integration/auth/register.spec.ts
+++ b/backend/tests/integration/auth/register.spec.ts
@@ -2,12 +2,13 @@ import type { z } from '@hono/zod-openapi'
 import type { RegisterSchema } from '@/schemas/auth.schema'
 import { testClient } from 'hono/testing'
 import * as status from 'stoker/http-status-codes'
-import { afterAll, assert, describe, expect, it } from 'vitest'
+import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest'
 import { MOCK_PROFILE, MOCK_USER } from '@/constants/seed.constant'
 import { UserRole } from '@/generated/prisma/enums'
 import { createTestApp } from '@/lib/config'
 import prisma from '@/lib/orm'
 import { auth } from '@/routes'
+import { seedInviteCodes } from '@/seeds'
 
 const client = testClient(createTestApp(auth))
 
@@ -22,8 +23,13 @@ describe('[Auth] Cadastro de usuário', () => {
     birthDate: new Date(MOCK_PROFILE.birthDate),
   }
 
+  beforeAll(async () => {
+    await seedInviteCodes()
+  })
+
   afterAll(async () => {
     await prisma.user.delete({ where: { email: basePayload.email } }).catch(() => {})
+    await prisma.inviteCode.deleteMany()
   })
 
   it('cadastra um aluno com dados de perfil com sucesso', async () => {
@@ -38,6 +44,8 @@ describe('[Auth] Cadastro de usuário', () => {
   })
 
   it('deve retornar erro ao tentar cadastrar com e-mail já existente', async () => {
+    await endpoint.$post({ json: basePayload })
+
     const res = await endpoint.$post({ json: basePayload })
 
     assert(res.status === status.CONFLICT)

--- a/backend/tests/integration/invites/lifecycle-flow.spec.ts
+++ b/backend/tests/integration/invites/lifecycle-flow.spec.ts
@@ -1,6 +1,8 @@
+import { cpf } from 'cpf-cnpj-validator'
 import { testClient } from 'hono/testing'
 import * as status from 'stoker/http-status-codes'
 import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest'
+import { MOCK_PROFILE } from '@/constants/seed.constant'
 import { UserRole } from '@/generated/prisma/enums'
 import { createTestApp } from '@/lib/config'
 import prisma from '@/lib/orm'
@@ -72,11 +74,14 @@ describe('[Invite Lifecycle Flow] Create → Validate → Consume → Block', ()
   it('[Passo 4] Novo usuário se registra e consome o código', async () => {
     const res = await authClient.auth.register.$post({
       json: {
+        ...MOCK_PROFILE,
+        cpf: cpf.generate(),
         name: 'New Student',
         email: 'new-student@test.com',
         password: 'Password123!',
         inviteCode: createdInviteCode,
         role: UserRole.ALUNO,
+        birthDate: new Date(MOCK_PROFILE.birthDate),
       },
     })
 
@@ -95,11 +100,14 @@ describe('[Invite Lifecycle Flow] Create → Validate → Consume → Block', ()
   it('[Passo 5] Tentativa de usar o mesmo código novamente retorna 400', async () => {
     const res = await authClient.auth.register.$post({
       json: {
+        ...MOCK_PROFILE,
+        cpf: cpf.generate(),
         name: 'Another Student',
         email: 'another-student@test.com',
         password: 'Password123!',
         role: UserRole.ALUNO,
         inviteCode: createdInviteCode,
+        birthDate: new Date(MOCK_PROFILE.birthDate),
       },
     })
 

--- a/backend/tests/integration/invites/lifecycle-flow.spec.ts
+++ b/backend/tests/integration/invites/lifecycle-flow.spec.ts
@@ -1,0 +1,160 @@
+import { testClient } from 'hono/testing'
+import * as status from 'stoker/http-status-codes'
+import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest'
+import { UserRole } from '@/generated/prisma/enums'
+import { createTestApp } from '@/lib/config'
+import prisma from '@/lib/orm'
+import { admin, auth } from '@/routes'
+import { seedUsers } from '@/seeds'
+import { getAuthHeaders } from '../../util'
+
+const adminClient = testClient(createTestApp(admin))
+const authClient = testClient(createTestApp(auth))
+
+describe('[Invite Lifecycle Flow] Create → Validate → Consume → Block', () => {
+  let adminHeaders: { Authorization: string }
+  let studentHeaders: { Authorization: string }
+  let createdInviteCode: string
+
+  beforeAll(async () => {
+    await seedUsers()
+    adminHeaders = await getAuthHeaders('admin@test.com', 'ADMIN')
+    studentHeaders = await getAuthHeaders('aluno@test.com', 'ALUNO')
+  })
+
+  afterAll(async () => {
+    await prisma.inviteCode.deleteMany()
+    await prisma.user.deleteMany({ where: { email: { in: ['new-student@test.com', 'another-student@test.com', 'revoked@test.com'] } } })
+  })
+
+  it('[Passo 1] ADMIN cria um convite para ALUNO', async () => {
+    const res = await adminClient.admin.invites.$post(
+      { json: { role: UserRole.ALUNO } },
+      { headers: adminHeaders },
+    )
+
+    expect(res.status).toBe(status.CREATED)
+    assert(res.status === status.CREATED)
+
+    const json = await res.json()
+    expect(json.code).toBeDefined()
+    createdInviteCode = json.code
+  })
+
+  it('[Passo 2] ALUNO tenta criar convite e recebe 403', async () => {
+    const res = await adminClient.admin.invites.$post(
+      { json: { role: UserRole.ALUNO } },
+      { headers: studentHeaders },
+    )
+
+    expect(res.status).toBe(status.FORBIDDEN)
+    assert(res.status === status.FORBIDDEN)
+  })
+
+  it('[Passo 3] ADMIN visualiza o convite criado na listagem', async () => {
+    const res = await adminClient.admin.invites.$get(
+      { query: { search: createdInviteCode } },
+      { headers: adminHeaders },
+    )
+
+    expect(res.status).toBe(status.OK)
+    assert(res.status === status.OK)
+
+    const json = await res.json()
+    assert(Array.isArray(json))
+
+    const exists = json.some(item =>
+      typeof item === 'string' ? item === createdInviteCode : item.code === createdInviteCode,
+    )
+    expect(exists).toBe(true)
+  })
+
+  it('[Passo 4] Novo usuário se registra e consome o código', async () => {
+    const res = await authClient.auth.register.$post({
+      json: {
+        name: 'New Student',
+        email: 'new-student@test.com',
+        password: 'Password123!',
+        inviteCode: createdInviteCode,
+        role: UserRole.ALUNO,
+      },
+    })
+
+    expect(res.status).toBe(status.CREATED)
+    assert(res.status === status.CREATED)
+
+    const json = await res.json()
+    expect(json.email).toBe('new-student@test.com')
+
+    const inviteInDb = await prisma.inviteCode.findUnique({ where: { code: createdInviteCode } })
+    assert(inviteInDb, 'O convite deveria existir no banco')
+    expect(inviteInDb.usedById).toBe(json.id)
+    expect(inviteInDb.usedAt).toBeDefined()
+  })
+
+  it('[Passo 5] Tentativa de usar o mesmo código novamente retorna 400', async () => {
+    const res = await authClient.auth.register.$post({
+      json: {
+        name: 'Another Student',
+        email: 'another-student@test.com',
+        password: 'Password123!',
+        role: UserRole.ALUNO,
+        inviteCode: createdInviteCode,
+      },
+    })
+
+    expect(res.status).toBe(status.BAD_REQUEST)
+    assert(res.status === status.BAD_REQUEST)
+
+    const json = await res.json()
+    expect(json.message).toMatch(/inválido ou expirado/i)
+  })
+
+  it('[Passo 6] ADMIN não pode revogar um convite já utilizado', async () => {
+    const invite = await prisma.inviteCode.findUnique({ where: { code: createdInviteCode } })
+    assert(invite)
+
+    const res = await adminClient.admin.invites[':id'].$delete(
+      { param: { id: invite.id } },
+      { headers: adminHeaders },
+    )
+
+    expect(res.status).toBe(status.CONFLICT)
+    assert(res.status === status.CONFLICT)
+
+    const json = await res.json()
+    expect(json.message).toMatch(/já foi utilizado/i)
+  })
+
+  it('[Passo 7] ADMIN revoga um convite ATIVO e ele se torna inutilizável', async () => {
+    const createRes = await adminClient.admin.invites.$post(
+      { json: { role: UserRole.COORDENADOR } },
+      { headers: adminHeaders },
+    )
+    expect(createRes.status).toBe(status.CREATED)
+    assert(createRes.status === status.CREATED)
+    const { id: inviteId, code: activeCode } = await createRes.json()
+
+    const revokeRes = await adminClient.admin.invites[':id'].$delete(
+      { param: { id: inviteId } },
+      { headers: adminHeaders },
+    )
+    expect(revokeRes.status).toBe(status.NO_CONTENT)
+
+    const registerRes = await authClient.auth.register.$post({
+      json: {
+        name: 'Revoked User',
+        email: 'revoked@test.com',
+        password: 'Password123!',
+        role: UserRole.COORDENADOR,
+        inviteCode: activeCode,
+      },
+    })
+
+    expect(registerRes.status).toBe(status.BAD_REQUEST)
+    assert(registerRes.status === status.BAD_REQUEST)
+
+    const json = await registerRes.json()
+    expect(json.message).toMatch(/inválido ou expirado/i)
+  })
+})

--- a/testes/backend/package-lock.json
+++ b/testes/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@prisma/client": "^7.6.0",
         "bcryptjs": "^3.0.3",
         "cpf-cnpj-validator": "^2.1.0",
+        "dayjs": "^1.11.20",
         "dotenv": "^17.4.0",
         "dotenv-expand": "^12.0.3",
         "hono": "^4.12.9",
@@ -840,6 +841,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",

--- a/testes/backend/package.json
+++ b/testes/backend/package.json
@@ -13,6 +13,7 @@
     "@prisma/client": "^7.6.0",
     "bcryptjs": "^3.0.3",
     "cpf-cnpj-validator": "^2.1.0",
+    "dayjs": "^1.11.20",
     "dotenv": "^17.4.0",
     "dotenv-expand": "^12.0.3",
     "hono": "^4.12.9",


### PR DESCRIPTION
## Why is this PR necessary, what does it do?
  * Implementa o sistema de convites para controle de acesso ao registro de novos usuários.
  * Utilização do padrão UTC  para evitar inconsistências de
    fuso horário.
  * Define regras básicas para a criação de convites:
    * Tempo de expiração padrão: 24 horas.
    * Tempo mínimo de expiração: 30 minutos.
  * Impede a revogação de convites que já foram utilizados ou que já estão expirados.

  * Adiciona testes de integração  para validar o ciclo de vida completo do convite.

Endpoints afetados:
  * POST /admin/invites
  * GET /admin/invites
  * DELETE /admin/invites/:id
  * POST /auth/register

##  References
  * Day.js UTC Plugin (https://day.js.org/docs/en/plugin/utc)
  * Zod SuperRefine (https://zod.dev/?id=superrefine)

##  Notes
  * Contribuição com testes: 
      * backend/tests/integration/invites/lifecycle-flow.spec.ts
  * Se aprovado, pode habilitar as seguintes tarefas de teste: 
      * #173 