### PR TITLE
Feat/backend/receipts

### DIFF
--- a/backend/prisma/migrations/20260512171719_add_attachment_to_cost_breakdown/migration.sql
+++ b/backend/prisma/migrations/20260512171719_add_attachment_to_cost_breakdown/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "CostBreakdown" ADD COLUMN     "attachmentKey" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -98,7 +98,7 @@ model Project {
   id                String            @id @default(uuid())
   name              String
   code              String            @unique
-  budget            Decimal          @db.Decimal(10, 2) 
+    budget            Decimal          @db.Decimal(10, 2) 
   usedBudget        Decimal          @default(0) @db.Decimal(10, 2)
   expenseCategories ExpenseCategory[]
   expenseRequests   ExpenseRequest[]
@@ -116,6 +116,8 @@ model CostBreakdown {
   expenseCategory   ExpenseCategory @relation(fields: [expenseCategoryId], references: [id])
   createdAt         DateTime        @default(now())
   updatedAt         DateTime        @updatedAt
+
+  attachmentKey String?
 }
 
 model InviteCode {

--- a/backend/src/constants/file.constant.ts
+++ b/backend/src/constants/file.constant.ts
@@ -1,3 +1,11 @@
 export const FILENAME_SANITIZE_REGEX = /[^\w.-]/g
 export const MEMORANDUM_UPLOAD_MAX_SIZE_MB = 5
+export const RECEIPT_UPLOAD_MAX_SIZE_MB = 10
 export const MEMORANDUM_DOWNLOAD_URL_EXPIRY_SECONDS = 3600
+export const COST_BREAKDOWN_RECEIPT_DOWNLOAD_URL_EXPIRY_SECONDS = 900
+
+export const ALLOWED_RECEIPT_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+] as const

--- a/backend/src/lib/storage.ts
+++ b/backend/src/lib/storage.ts
@@ -34,7 +34,9 @@ function getClient(): S3Client {
 export type UploadFileOptions = {
   file: File
   contentType: string
-  folder: 'memorandos' | 'admin-attachments'
+  folder: 'memorandos' | 'comprovantes'
+  subfolder?: string
+  prefix?: string
 }
 
 export type UploadFileResult = {
@@ -44,10 +46,13 @@ export type UploadFileResult = {
 }
 
 export async function uploadFile(options: UploadFileOptions): Promise<UploadFileResult> {
-  const { file, contentType, folder } = options
+  const { file, contentType, folder, subfolder, prefix } = options
   const uniqueId = crypto.randomUUID()
   const sanitizedFileName = file.name.replace(FILENAME_SANITIZE_REGEX, '_')
-  const fileKey = `${folder}/${uniqueId}-${sanitizedFileName}`
+
+  const path = subfolder ? `${folder}/${subfolder}` : folder
+  const fileName = prefix ? `${prefix}_${uniqueId}-${sanitizedFileName}` : `${uniqueId}-${sanitizedFileName}`
+  const fileKey = `${path}/${fileName}`
 
   const command = new PutObjectCommand({
     Bucket: env.R2_BUCKET_NAME!,

--- a/backend/src/middlewares/upload-settings.ts
+++ b/backend/src/middlewares/upload-settings.ts
@@ -1,6 +1,7 @@
 import { bodyLimit } from 'hono/body-limit'
 import { createMiddleware } from 'hono/factory'
 import * as codes from 'stoker/http-status-codes'
+import { ALLOWED_RECEIPT_MIME_TYPES, RECEIPT_UPLOAD_MAX_SIZE_MB } from '@/constants/file.constant'
 
 export type UploadOptions = {
   maxFileSizeMB: number
@@ -49,5 +50,11 @@ export default function uploadSettings(options: UploadOptions) {
 export const uploadMemorandumSettings = uploadSettings({
   maxFileSizeMB: 5,
   allowedMimeFileTypes: ['application/pdf'],
+  fieldName: 'file',
+})
+
+export const uploadReceiptSettings = uploadSettings({
+  maxFileSizeMB: RECEIPT_UPLOAD_MAX_SIZE_MB,
+  allowedMimeFileTypes: ALLOWED_RECEIPT_MIME_TYPES,
   fieldName: 'file',
 })

--- a/backend/src/routes/expenses/cost-breakdowns/cost-breakdowns.handler.ts
+++ b/backend/src/routes/expenses/cost-breakdowns/cost-breakdowns.handler.ts
@@ -1,0 +1,102 @@
+import type { CreateRoute, GetReceiptDownloadRoute, RemoveReceiptRoute, UploadReceiptRoute } from './cost-breakdowns.route'
+import type { AppRouteHandler } from '@/lib/type'
+import * as codes from 'stoker/http-status-codes'
+import * as phrases from 'stoker/http-status-phrases'
+import { PROJECT_ERROR_CODES } from '@/constants/project.constant'
+import { CostBreakdownResponseSchema, ReceiptDownloadUrlSchema } from '@/schemas/cost-breakdown.schema'
+import { createCostBreakdown, deleteCostBreakdownReceipt, getCostBreakdownReceiptUrl, uploadCostBreakdownReceipt } from '@/services/budget.service'
+
+export const create: AppRouteHandler<CreateRoute> = async (c) => {
+  const { id } = c.req.valid('param')
+  const data = c.req.valid('json')
+
+  const result = await createCostBreakdown(id, data)
+
+  if ('error' in result) {
+    switch (result.error) {
+      case phrases.NOT_FOUND:
+        return c.json({ message: 'Despesa ou Projeto não encontrados' }, codes.NOT_FOUND)
+      case PROJECT_ERROR_CODES.PROJECT_ARCHIVED:
+        return c.json({ message: 'Este projeto está arquivado e não pode receber discriminação de custo.' }, codes.CONFLICT)
+      case PROJECT_ERROR_CODES.INSUFFICIENT_FUNDS:
+        return c.json({ message: 'Projeto não possui budget suficiente.' }, codes.BAD_REQUEST)
+      case PROJECT_ERROR_CODES.INVALID_SUBCATEGORIES_COUNT:
+        return c.json({ message: 'Subcategoria inválida para este projeto.' }, codes.BAD_REQUEST)
+      default:
+        return c.json({ message: result.error }, codes.BAD_REQUEST)
+    }
+  }
+
+  const parsed = CostBreakdownResponseSchema.parse({
+    ...result,
+    subcategory: result.expenseCategory,
+  })
+  return c.json(parsed, codes.CREATED)
+}
+
+export const uploadReceipt: AppRouteHandler<UploadReceiptRoute> = async (c) => {
+  const { id, breakdownId } = c.req.valid('param')
+  const { file } = c.req.valid('form')
+
+  const result = await uploadCostBreakdownReceipt(id, breakdownId, file)
+
+  if ('error' in result) {
+    switch (result.error) {
+      case phrases.NOT_FOUND:
+        return c.json({ message: 'Despesa ou Discriminação não encontrada' }, codes.NOT_FOUND)
+      case 'STORAGE_NOT_CONFIGURED':
+        return c.json({ message: 'Armazenamento não configurado' }, codes.SERVICE_UNAVAILABLE)
+      case phrases.BAD_GATEWAY:
+        return c.json({ message: 'Falha na comunicação com o provedor de armazenamento' }, codes.BAD_GATEWAY)
+      default:
+        return c.json({ message: result.error }, codes.BAD_REQUEST)
+    }
+  }
+
+  const parsed = CostBreakdownResponseSchema.parse({
+    ...result,
+    subcategory: result.expenseCategory,
+  })
+  return c.json(parsed, codes.OK)
+}
+
+export const removeReceipt: AppRouteHandler<RemoveReceiptRoute> = async (c) => {
+  const { id, breakdownId } = c.req.valid('param')
+
+  const result = await deleteCostBreakdownReceipt(id, breakdownId)
+
+  if ('error' in result) {
+    switch (result.error) {
+      case phrases.NOT_FOUND:
+        return c.json({ message: 'Comprovante não encontrado.' }, codes.NOT_FOUND)
+      case phrases.BAD_GATEWAY:
+        return c.json({ message: 'Falha ao remover arquivo do armazenamento (Cloudflare R2)' }, codes.BAD_GATEWAY)
+      default:
+        return c.json({ message: result.error }, codes.BAD_REQUEST)
+    }
+  }
+
+  return c.body(null, codes.NO_CONTENT)
+}
+
+export const getReceiptDownload: AppRouteHandler<GetReceiptDownloadRoute> = async (c) => {
+  const { id, breakdownId } = c.req.valid('param')
+  const { sub, role } = c.get('jwtPayload')
+
+  const result = await getCostBreakdownReceiptUrl(id, breakdownId, sub, role)
+
+  if ('error' in result) {
+    switch (result.error) {
+      case phrases.NOT_FOUND:
+        return c.json({ message: 'Comprovante não encontrado.' }, codes.NOT_FOUND)
+      case 'STORAGE_NOT_CONFIGURED':
+        return c.json({ message: 'Armazenamento não configurado.' }, codes.SERVICE_UNAVAILABLE)
+      case phrases.BAD_GATEWAY:
+        return c.json({ message: 'Falha na comunicação com o provedor de armazenamento.' }, codes.BAD_GATEWAY)
+    }
+  }
+
+  const parsed = ReceiptDownloadUrlSchema.parse(result)
+
+  return c.json(parsed, codes.OK)
+}

--- a/backend/src/routes/expenses/cost-breakdowns/cost-breakdowns.route.ts
+++ b/backend/src/routes/expenses/cost-breakdowns/cost-breakdowns.route.ts
@@ -1,0 +1,161 @@
+import { createRoute, z } from '@hono/zod-openapi'
+import * as codes from 'stoker/http-status-codes'
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers'
+import { createMessageObjectSchema } from 'stoker/openapi/schemas'
+import { UserRole } from '@/generated/prisma/enums'
+import { multipartFormContentRequired } from '@/lib/util'
+import { requireAuth, requireRole } from '@/middlewares'
+import { uploadReceiptSettings } from '@/middlewares/upload-settings'
+import { CostBreakdownResponseSchema, CreateCostBreakdownSchema, ReceiptDownloadUrlSchema, UploadReceiptSchema } from '@/schemas/cost-breakdown.schema'
+import { ForbiddenResponse, IdSchema, UnauthorizedResponse } from '@/schemas/shared.schema'
+
+const tags = ['Cost Breakdowns']
+
+export type CreateRoute = typeof create
+export type UploadReceiptRoute = typeof uploadReceipt
+export type RemoveReceiptRoute = typeof removeReceipt
+export type GetReceiptDownloadRoute = typeof getReceiptDownload
+
+export const create = createRoute({
+  path: '/',
+  method: 'post',
+  middleware: [requireAuth, requireRole([UserRole.ADMIN])],
+  security: [{ bearerAuth: [] }],
+  summary: 'Add cost breakdown to expense',
+  description: 'Adiciona uma discriminação de custo a uma solicitação de despesa. Restrito a ADMIN.',
+  tags,
+  request: {
+    params: z.object({ id: IdSchema }),
+    body: jsonContentRequired(CreateCostBreakdownSchema, 'Detalhes da discriminação de custo'),
+  },
+  responses: {
+    [codes.CREATED]: jsonContent(
+      CostBreakdownResponseSchema,
+      'Discriminação salva com sucesso.',
+    ),
+    [codes.BAD_REQUEST]: jsonContent(
+      createMessageObjectSchema('Erro de validação'),
+      'Erro de regra de negócio (ex: Budget insuficiente, Categoria inválida).',
+    ),
+    [codes.CONFLICT]: jsonContent(
+      createMessageObjectSchema('Operação inválida'),
+      'O projeto está arquivado ou não pode receber discriminação de custo.',
+    ),
+    [codes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Despesa não encontrada'),
+      'A despesa não existe ou não possui projeto vinculado.',
+    ),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+    [codes.FORBIDDEN]: ForbiddenResponse,
+  },
+})
+
+export const uploadReceipt = createRoute({
+  path: '/{breakdownId}/receipt',
+  method: 'post',
+  middleware: [
+    requireAuth,
+    requireRole([UserRole.ADMIN]),
+    uploadReceiptSettings.size,
+    uploadReceiptSettings.content,
+  ],
+  security: [{ bearerAuth: [] }],
+  summary: 'Upload receipt to cost breakdown',
+  description: 'Faz upload de um arquivo de comprovante para uma discriminação de custo existente.',
+  tags,
+  request: {
+    params: z.object({
+      id: IdSchema,
+      breakdownId: IdSchema,
+    }),
+    body: multipartFormContentRequired(UploadReceiptSchema, 'Arquivo de comprovante (PDF, Imagem)'),
+  },
+  responses: {
+    [codes.OK]: jsonContent(
+      CostBreakdownResponseSchema,
+      'Comprovante anexado com sucesso.',
+    ),
+    [codes.BAD_REQUEST]: jsonContent(
+      createMessageObjectSchema('Erro na requisição'),
+      'Arquivo inválido ou erro de processamento.',
+    ),
+    [codes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Não encontrado'),
+      'Despesa ou Discriminação de custo não encontrados.',
+    ),
+    [codes.SERVICE_UNAVAILABLE]: jsonContent(
+      createMessageObjectSchema('Armazenamento indisponível'),
+      'Variáveis R2 não configuradas.',
+    ),
+    [codes.BAD_GATEWAY]: jsonContent(
+      createMessageObjectSchema('Erro no provedor de armazenamento'),
+      'Falha na comunicação com o Cloudflare R2.',
+    ),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+    [codes.FORBIDDEN]: ForbiddenResponse,
+  },
+})
+
+export const removeReceipt = createRoute({
+  path: '/{breakdownId}/receipt',
+  method: 'delete',
+  middleware: [requireAuth, requireRole([UserRole.ADMIN])],
+  security: [{ bearerAuth: [] }],
+  summary: 'Delete receipt from cost breakdown',
+  description: 'Remove o comprovante do banco de dados e do armazenamento R2. Restrito a ADMIN.',
+  tags,
+  request: {
+    params: z.object({
+      id: IdSchema,
+      breakdownId: IdSchema,
+    }),
+  },
+  responses: {
+    [codes.NO_CONTENT]: { description: 'Comprovante removido com sucesso.' },
+    [codes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Não encontrado'),
+      'Comprovante não encontrado.',
+    ),
+    [codes.BAD_GATEWAY]: jsonContent(
+      createMessageObjectSchema('Erro no provedor de armazenamento'),
+      'Falha na comunicação com o Cloudflare R2.',
+    ),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+    [codes.FORBIDDEN]: ForbiddenResponse,
+  },
+})
+
+export const getReceiptDownload = createRoute({
+  path: '/{breakdownId}/receipt/download',
+  method: 'get',
+  middleware: [requireAuth],
+  security: [{ bearerAuth: [] }],
+  summary: 'URL assinada para download do comprovante',
+  description: 'Retorna uma URL pré-assinada válida por 15 min para baixar o comprovante de um cost breakdown. Acesso: ADMIN ou dono da despesa.',
+  tags,
+  request: {
+    params: z.object({
+      id: IdSchema,
+      breakdownId: IdSchema,
+    }),
+  },
+  responses: {
+    [codes.OK]: jsonContent(
+      ReceiptDownloadUrlSchema,
+      'URL gerada com sucesso.',
+    ),
+    [codes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Não encontrado'),
+      'Comprovante não encontrado ou despesa inexistente.',
+    ),
+    [codes.SERVICE_UNAVAILABLE]: jsonContent(
+      createMessageObjectSchema('Armazenamento indisponível'),
+      'Variáveis R2 não configuradas.',
+    ),
+    [codes.BAD_GATEWAY]: jsonContent(
+      createMessageObjectSchema('Erro no provedor de armazenamento'),
+      'Falha na comunicação com o Cloudflare R2.',
+    ),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+  },
+})

--- a/backend/src/routes/expenses/cost-breakdowns/index.ts
+++ b/backend/src/routes/expenses/cost-breakdowns/index.ts
@@ -1,0 +1,12 @@
+import { createRouter } from '@/lib/util'
+import * as handlers from './cost-breakdowns.handler'
+import * as routes from './cost-breakdowns.route'
+
+const router = createRouter()
+  .basePath('/:id/cost-breakdowns')
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.uploadReceipt, handlers.uploadReceipt)
+  .openapi(routes.removeReceipt, handlers.removeReceipt)
+  .openapi(routes.getReceiptDownload, handlers.getReceiptDownload)
+
+export default router

--- a/backend/src/routes/expenses/expenses.handler.ts
+++ b/backend/src/routes/expenses/expenses.handler.ts
@@ -40,7 +40,15 @@ export const read: AppRouteHandler<ReadRoute> = async (c) => {
     return c.json({ message: 'Despesa não encontrada' }, codes.NOT_FOUND)
   }
 
-  const parsed = ExpenseResponseSchema.parse(data)
+  const payload = {
+    ...data,
+    costBreakdowns: data.costBreakdowns?.map(cb => ({
+      ...cb,
+      subcategory: cb.expenseCategory,
+    })),
+  }
+
+  const parsed = ExpenseResponseSchema.parse(payload)
   return c.json(parsed, codes.OK)
 }
 

--- a/backend/src/routes/expenses/expenses.handler.ts
+++ b/backend/src/routes/expenses/expenses.handler.ts
@@ -1,12 +1,10 @@
-import type { AssignProjectRoute, CreateCostBreakdownRoute, CreateRoute, GetMemorandumDownloadRoute, IndexRoute, ReadRoute, UpdateStatusRoute, UploadMemorandumRoute } from './expenses.route'
+import type { AssignProjectRoute, CreateRoute, GetMemorandumDownloadRoute, IndexRoute, ReadRoute, UpdateStatusRoute, UploadMemorandumRoute } from './expenses.route'
 import type { AppRouteHandler } from '@/lib/type'
 import * as codes from 'stoker/http-status-codes'
 import * as phrases from 'stoker/http-status-phrases'
 import { EXPENSE_ERROR_CODES } from '@/constants/expense.constant'
 import { PROJECT_ERROR_CODES } from '@/constants/project.constant'
-import { CostBreakdownResponseSchema } from '@/schemas/cost-breakdown.schema'
 import { AssignProjectResponseSchema, CreateExpenseResponseSchema, ExpenseResponseSchema, ListExpenseResponseSchema } from '@/schemas/expense.schema'
-import { createCostBreakdown as createCostBreakdownService } from '@/services/budget.service'
 import { assignProjectToExpense, attachMemorandumToExpense, createExpenseRequest, getAllExpenseRequests, getExpenseById, getMemorandumDownloadUrl, updateExpenseStatus } from '@/services/expense.service'
 
 export const index: AppRouteHandler<IndexRoute> = async (c) => {
@@ -101,31 +99,6 @@ export const assignProject: AppRouteHandler<AssignProjectRoute> = async (c) => {
   }
   const parsed = AssignProjectResponseSchema.parse(result)
   return c.json(parsed, codes.OK)
-}
-
-export const createCostBreakdown: AppRouteHandler<CreateCostBreakdownRoute> = async (c) => {
-  const { id } = c.req.valid('param')
-  const data = c.req.valid('json')
-
-  const result = await createCostBreakdownService(id, data)
-
-  if ('error' in result) {
-    if (result.error === phrases.NOT_FOUND) {
-      return c.json({ message: 'Despesa ou Projeto não encontrados' }, codes.NOT_FOUND)
-    }
-
-    if (result.error === PROJECT_ERROR_CODES.PROJECT_ARCHIVED) {
-      return c.json({ message: 'Este projeto está arquivado e não pode receber discriminação de custo.' }, codes.CONFLICT)
-    }
-
-    return c.json({ message: result.error }, codes.BAD_REQUEST)
-  }
-
-  const parsed = CostBreakdownResponseSchema.parse({
-    ...result,
-    subcategory: result.expenseCategory,
-  })
-  return c.json(parsed, codes.CREATED)
 }
 
 export const uploadMemorandum: AppRouteHandler<UploadMemorandumRoute> = async (c) => {

--- a/backend/src/routes/expenses/expenses.route.ts
+++ b/backend/src/routes/expenses/expenses.route.ts
@@ -6,7 +6,6 @@ import { UserRole } from '@/generated/prisma/enums'
 import { multipartFormContentRequired } from '@/lib/util'
 import { requireAuth, requireRole } from '@/middlewares'
 import { uploadMemorandumSettings } from '@/middlewares/upload-settings'
-import { CostBreakdownResponseSchema, CreateCostBreakdownSchema } from '@/schemas/cost-breakdown.schema'
 import { AssignProjectResponseSchema, CreateExpenseResponseSchema, CreateExpenseSchema, ExpenseListQuerySchema, ExpenseResponseSchema, ListExpenseResponseSchema, UpdateExpenseStatusSchema, UploadMemorandumSchema } from '@/schemas/expense.schema'
 import { ForbiddenResponse, IdSchema, UnauthorizedResponse } from '@/schemas/shared.schema'
 
@@ -17,7 +16,6 @@ export type IndexRoute = typeof index
 export type ReadRoute = typeof read
 export type UpdateStatusRoute = typeof updateStatus
 export type AssignProjectRoute = typeof assignProject
-export type CreateCostBreakdownRoute = typeof createCostBreakdown
 export type UploadMemorandumRoute = typeof uploadMemorandum
 export type GetMemorandumDownloadRoute = typeof getMemorandumDownload
 
@@ -144,40 +142,6 @@ export const assignProject = createRoute({
     [codes.CONFLICT]: jsonContent(
       createMessageObjectSchema('Operação inválida'),
       'A solicitação não está com status APROVADO, o projeto está arquivado ou o projeto não possui budget suficiente.',
-    ),
-    [codes.UNAUTHORIZED]: UnauthorizedResponse,
-    [codes.FORBIDDEN]: ForbiddenResponse,
-  },
-})
-
-export const createCostBreakdown = createRoute({
-  path: '/{id}/cost-breakdown',
-  method: 'post',
-  middleware: [requireAuth, requireRole([UserRole.ADMIN])],
-  security: [{ bearerAuth: [] }],
-  summary: 'Add cost breakdown to expense',
-  description: 'Adiciona uma discriminação de custo a uma solicitação de despesa. Restrito a ADMIN.',
-  tags,
-  request: {
-    params: z.object({ id: IdSchema }),
-    body: jsonContentRequired(CreateCostBreakdownSchema, 'Detalhes da discriminação de custo'),
-  },
-  responses: {
-    [codes.CREATED]: jsonContent(
-      CostBreakdownResponseSchema,
-      'Discriminação salva com sucesso.',
-    ),
-    [codes.BAD_REQUEST]: jsonContent(
-      createMessageObjectSchema('Erro de validação'),
-      'Erro de regra de negócio (ex: Budget insuficiente, Categoria inválida).',
-    ),
-    [codes.CONFLICT]: jsonContent(
-      createMessageObjectSchema('Operação inválida'),
-      'O projeto está arquivado ou não pode receber discriminação de custo.',
-    ),
-    [codes.NOT_FOUND]: jsonContent(
-      createMessageObjectSchema('Despesa não encontrada'),
-      'A despesa não existe ou não possui projeto vinculado.',
     ),
     [codes.UNAUTHORIZED]: UnauthorizedResponse,
     [codes.FORBIDDEN]: ForbiddenResponse,

--- a/backend/src/routes/expenses/index.ts
+++ b/backend/src/routes/expenses/index.ts
@@ -1,10 +1,12 @@
 import { createRouter } from '@/lib/util'
 import categories from './categories'
+import costBreakdowns from './cost-breakdowns'
 import * as handlers from './expenses.handler'
 import * as routes from './expenses.route'
 
 const router = createRouter().basePath('/expenses')
   .route('/', categories)
+  .route('/', costBreakdowns)
   .openapi(routes.index, handlers.index)
   .openapi(routes.create, handlers.create)
   .openapi(routes.read, handlers.read)
@@ -12,6 +14,5 @@ const router = createRouter().basePath('/expenses')
   .openapi(routes.getMemorandumDownload, handlers.getMemorandumDownload)
   .openapi(routes.updateStatus, handlers.updateStatus)
   .openapi(routes.assignProject, handlers.assignProject)
-  .openapi(routes.createCostBreakdown, handlers.createCostBreakdown)
 
 export default router

--- a/backend/src/schemas/cost-breakdown.schema.ts
+++ b/backend/src/schemas/cost-breakdown.schema.ts
@@ -1,8 +1,10 @@
 import { z } from '@hono/zod-openapi'
+import { COST_BREAKDOWN_RECEIPT_DOWNLOAD_URL_EXPIRY_SECONDS, RECEIPT_UPLOAD_MAX_SIZE_MB } from '@/constants/file.constant'
 import { dummyExpenseCategories } from '@/seeds/expense.category.seed'
 import { normalizeCategoryName } from '@/services/expense.category.service'
 import ExpenseCategoryBaseSchema from './expense.category.schema'
-import { IdSchema } from './shared.schema'
+import { validReceiptFileCheck } from './schema.refine'
+import { FileItemSchema, IdSchema } from './shared.schema'
 
 const BaseSchema = z.object({
   id: IdSchema,
@@ -13,6 +15,9 @@ const BaseSchema = z.object({
     }),
   amount: z.number().positive()
     .openapi({ example: 150.50 }),
+  attachmentKey: z.string().nullable()
+    .optional()
+    .openapi({ description: 'Chave do comprovante no armazenamento R2' }),
 })
 
 export const CreateCostBreakdownSchema = BaseSchema.omit({ id: true })
@@ -23,4 +28,28 @@ export const CostBreakdownResponseSchema = z.object({
   amount: z.coerce.number()
     .openapi({ example: 150.50 }),
   subcategory: ExpenseCategoryBaseSchema,
+  attachmentKey: z.string().nullable()
+    .optional(),
+})
+
+export const UploadReceiptSchema = z.object({
+  file: FileItemSchema.superRefine(validReceiptFileCheck(RECEIPT_UPLOAD_MAX_SIZE_MB))
+    .openapi({
+      type: 'string',
+      format: 'binary',
+      description: `Arquivo de comprovante (PDF, JPG, PNG). Tamanho máximo permitido: ${RECEIPT_UPLOAD_MAX_SIZE_MB}MB.`,
+    }),
+})
+
+export const ReceiptDownloadUrlSchema = z.object({
+  url: z.url()
+    .openapi({
+      description: 'URL assinada para download do comprovante',
+      example: 'https://r2.example.com/comprovantes/inscricao_uuid_receipt.pdf?token=...',
+    }),
+  expiresIn: z.number()
+    .openapi({
+      description: 'Tempo de expiração da URL em segundos',
+      example: COST_BREAKDOWN_RECEIPT_DOWNLOAD_URL_EXPIRY_SECONDS,
+    }),
 })

--- a/backend/src/schemas/cost-breakdown.schema.ts
+++ b/backend/src/schemas/cost-breakdown.schema.ts
@@ -17,7 +17,7 @@ const BaseSchema = z.object({
     .openapi({ example: 150.50 }),
   attachmentKey: z.string().nullable()
     .optional()
-    .openapi({ description: 'Chave do comprovante no armazenamento R2' }),
+    .openapi({ description: 'Chave do comprovante no armazenamento R2. Pode ser usado no cadastro para reaproveitar um arquivo já enviado anteriormente.' }),
 })
 
 export const CreateCostBreakdownSchema = BaseSchema.omit({ id: true })

--- a/backend/src/schemas/schema.refine.ts
+++ b/backend/src/schemas/schema.refine.ts
@@ -4,6 +4,7 @@ import { z } from '@hono/zod-openapi'
 import countries from 'i18n-iso-countries'
 import iso31662 from 'iso-3166-2'
 import { STATUSES_WHERE_REASON_REQUIRED } from '@/constants/expense.constant'
+import { ALLOWED_RECEIPT_MIME_TYPES } from '@/constants/file.constant'
 import { INVITE_STATUS } from '@/constants/invite.constant'
 import { dayjs } from '@/lib/date'
 import { validatePDF } from '@/lib/storage'
@@ -133,3 +134,24 @@ export const usedInviteFieldsRequired = z.refine<{
     path: ['status'],
   },
 )
+
+export function validReceiptFileCheck(maxSizeInMB: number) {
+  const maxSizeBytes = maxSizeInMB * 1024 * 1024
+
+  return (value: File, ctx: z.RefinementCtx) => {
+    if (value.size > maxSizeBytes) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Arquivo excede o tamanho máximo de ${maxSizeInMB}MB`,
+      })
+      return
+    }
+
+    if (!(ALLOWED_RECEIPT_MIME_TYPES as readonly string[]).includes(value.type)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Formato de arquivo não suportado. Use PDF ou Imagens (JPG, PNG).',
+      })
+    }
+  }
+}

--- a/backend/src/services/budget.service.ts
+++ b/backend/src/services/budget.service.ts
@@ -1,9 +1,12 @@
 import type { z } from '@hono/zod-openapi'
 import type { CreateCostBreakdownSchema } from '@/schemas/cost-breakdown.schema'
 import * as phrases from 'stoker/http-status-phrases'
+import { COST_BREAKDOWN_RECEIPT_DOWNLOAD_URL_EXPIRY_SECONDS } from '@/constants/file.constant'
 import { PROJECT_ERROR_CODES } from '@/constants/project.constant'
 import { Prisma } from '@/generated/prisma/client'
+import { UserRole } from '@/generated/prisma/enums'
 import prisma from '@/lib/orm'
+import { deleteFile, getSignedDownloadUrl, isStorageConfigured, uploadFile } from '@/lib/storage'
 
 type BudgetMetricsResult = { total: Prisma.Decimal, used: Prisma.Decimal, available: Prisma.Decimal, isActive: boolean }
 
@@ -95,6 +98,7 @@ export async function createCostBreakdown(
         amount: data.amount,
         expenseRequest: { connect: { id: expenseRequestId } },
         expenseCategory: { connect: { normalizedName: data.subcategoryName } },
+        attachmentKey: data.attachmentKey,
       },
       include: { expenseCategory: true },
     })
@@ -108,4 +112,125 @@ export async function createCostBreakdown(
   }, { isolationLevel: 'Serializable' })
 
   return result
+}
+
+export async function uploadCostBreakdownReceipt(
+  expenseId: string,
+  breakdownId: string,
+  file: File,
+) {
+  if (!isStorageConfigured()) {
+    return { error: 'STORAGE_NOT_CONFIGURED' }
+  }
+
+  const breakdown = await prisma.costBreakdown.findFirst({
+    where: {
+      id: breakdownId,
+      expenseRequestId: expenseId,
+    },
+    include: { expenseCategory: true },
+  })
+
+  if (!breakdown) {
+    return { error: phrases.NOT_FOUND }
+  }
+
+  if (breakdown.attachmentKey) {
+    try {
+      await deleteFile(breakdown.attachmentKey)
+    }
+    catch (error) {
+      console.error('Failed to delete previous file from R2:', error)
+      return { error: phrases.BAD_GATEWAY }
+    }
+  }
+
+  try {
+    const uploaded = await uploadFile({
+      file,
+      contentType: file.type,
+      folder: 'comprovantes',
+      subfolder: expenseId,
+      prefix: breakdown.expenseCategory.normalizedName,
+    })
+
+    const updatedBreakdown = await prisma.costBreakdown.update({
+      where: { id: breakdownId },
+      data: { attachmentKey: uploaded.fileKey },
+      include: { expenseCategory: true },
+    })
+
+    return updatedBreakdown
+  }
+  catch (error) {
+    console.error('R2 Upload error:', error)
+    return { error: phrases.BAD_GATEWAY }
+  }
+}
+
+export async function deleteCostBreakdownReceipt(
+  expenseId: string,
+  breakdownId: string,
+) {
+  const breakdown = await prisma.costBreakdown.findFirst({
+    where: {
+      id: breakdownId,
+      expenseRequestId: expenseId,
+    },
+  })
+
+  if (!breakdown || !breakdown.attachmentKey) {
+    return { error: phrases.NOT_FOUND }
+  }
+
+  try {
+    await deleteFile(breakdown.attachmentKey)
+
+    await prisma.costBreakdown.update({
+      where: { id: breakdownId },
+      data: { attachmentKey: null },
+    })
+
+    return { success: true }
+  }
+  catch (error) {
+    console.error('R2 Delete error:', error)
+    return { error: phrases.BAD_GATEWAY }
+  }
+}
+
+export async function getCostBreakdownReceiptUrl(
+  expenseId: string,
+  breakdownId: string,
+  userId: string,
+  role: UserRole,
+) {
+  if (!isStorageConfigured()) {
+    return { error: 'STORAGE_NOT_CONFIGURED' }
+  }
+
+  const breakdown = await prisma.costBreakdown.findFirst({
+    where: {
+      id: breakdownId,
+      expenseRequestId: expenseId,
+      ...(role !== UserRole.ADMIN && { expenseRequest: { studentId: userId } }),
+    },
+    select: { attachmentKey: true },
+  })
+
+  if (!breakdown || !breakdown.attachmentKey) {
+    return { error: phrases.NOT_FOUND }
+  }
+
+  try {
+    const url = await getSignedDownloadUrl(breakdown.attachmentKey, COST_BREAKDOWN_RECEIPT_DOWNLOAD_URL_EXPIRY_SECONDS)
+    return {
+      url,
+      expiresIn: COST_BREAKDOWN_RECEIPT_DOWNLOAD_URL_EXPIRY_SECONDS,
+    }
+  }
+  catch (error) {
+    console.error('R2 Pre-sign error:', error)
+    return { error: phrases.BAD_GATEWAY }
+  }
 }

--- a/backend/src/services/expense.service.ts
+++ b/backend/src/services/expense.service.ts
@@ -38,6 +38,7 @@ export const expenseInclude = {
           normalizedName: true,
         },
       },
+      attachmentKey: true,
     },
   },
 } satisfies Prisma.ExpenseRequestInclude

--- a/backend/src/services/expense.service.ts
+++ b/backend/src/services/expense.service.ts
@@ -30,6 +30,7 @@ export const expenseInclude = {
   costBreakdowns: {
     select: {
       id: true,
+      expenseRequestId: true,
       amount: true,
       expenseCategory: {
         select: {

--- a/backend/tests/integration/cost-breakdown/archived-project.spec.ts
+++ b/backend/tests/integration/cost-breakdown/archived-project.spec.ts
@@ -53,14 +53,16 @@ describe('[Expense] Criar cost breakdown em projeto arquivado', () => {
   })
 
   it('não permite criar cost breakdown para projeto arquivado', async () => {
-    const endpoint = client.expenses[':id']['cost-breakdown'].$post
+    const endpoint = client.expenses[':id']['cost-breakdowns'].$post
     const res = await endpoint(
       {
         param: { id: expenseId },
         json: {
           amount: 100,
           subcategoryName: dummyExpenseCategories[0]!.normalizedName,
+          attachmentKey: 'key/abc.pdf',
         },
+
       },
       { headers: adminHeaders },
     )


### PR DESCRIPTION
## Why is this PR necessary, what does it do?
*  Permite discriminar valores e vincular comprovantes específicos por categoria de despesa.
*  Implementa upload, exclusão e download seguro de anexos (PDF, JPG, PNG).
*  Restringe a visualização de documentos a usuários autenticados utilizando URLs assinadas de curta duração (15 min).

## Endpoints afetados
* `POST /expenses/:id/cost-breakdowns`
* `POST /expenses/:id/cost-breakdowns/:breakdownId/receipt`
* `DELETE /expenses/:id/cost-breakdowns/:breakdownId/receipt`
* `GET /expenses/:id/cost-breakdowns/:breakdownId/receipt/download`

## References
* Cloudflare R2 Storage API
* Zod SuperRefine

## Notes
* **Prevenção de IDOR:** A API retorna `404 Not Found` (ao invés de `403`) ao tentar acessar despesas de terceiros, ocultando a existência do recurso.
* **Reaproveitamento de Anexos:** O envio do `attachmentKey` na criação do *breakdown* permite reaproveitar arquivos já presentes no storage, evitando uploads duplicados.
* **Infraestrutura:** O funcionamento exige as credenciais do R2 no ambiente (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`).