### PR TITLE
fix(expense): flow EM_EDICAO -> APROVADO and role visibility

### DIFF
--- a/backend/src/constants/expense.constant.ts
+++ b/backend/src/constants/expense.constant.ts
@@ -1,4 +1,4 @@
-import { ExpenseRequestStatus } from '@/generated/prisma/enums'
+import { ExpenseRequestStatus, UserRole } from '@/generated/prisma/enums'
 
 export const STATUSES_WHERE_REASON_REQUIRED: ExpenseRequestStatus[] = [
   ExpenseRequestStatus.REJEITADO,
@@ -15,11 +15,25 @@ export const EXPENSE_STATUS_TRANSITIONS: Record<ExpenseRequestStatus, ExpenseReq
     ExpenseRequestStatus.EM_PROCESSAMENTO,
   ],
   [ExpenseRequestStatus.EM_EDICAO]: [
-    ExpenseRequestStatus.PENDENTE,
+    ExpenseRequestStatus.APROVADO,
   ],
   [ExpenseRequestStatus.REJEITADO]: [],
   [ExpenseRequestStatus.EM_PROCESSAMENTO]: [],
 } as const
+
+export const EXPENSE_VISIBILITY_BY_ROLE: Record<UserRole, ExpenseRequestStatus[]> = {
+  [UserRole.ALUNO]: Object.values(ExpenseRequestStatus),
+  [UserRole.COORDENADOR]: [
+    ExpenseRequestStatus.PENDENTE,
+    ExpenseRequestStatus.APROVADO,
+    ExpenseRequestStatus.REJEITADO,
+  ],
+  [UserRole.ADMIN]: [
+    ExpenseRequestStatus.APROVADO,
+    ExpenseRequestStatus.EM_EDICAO,
+    ExpenseRequestStatus.EM_PROCESSAMENTO,
+  ],
+}
 
 export const EXPENSE_ERROR_CODES = {
   REASON_REQUIRED: 'REASON_REQUIRED',

--- a/backend/src/routes/expenses/expenses.route.ts
+++ b/backend/src/routes/expenses/expenses.route.ts
@@ -86,7 +86,7 @@ export const update = createRoute({
   summary: 'Update expense',
   description: `
     Permite que o aluno atualize os dados de uma solicitação que está no status 'EM_EDICAO'.
-    Ao salvar, o status retorna para 'PENDENTE' e o motivo de correção é limpo.
+    Ao salvar, o status retorna para 'APROVADO' e o motivo de correção é limpo.
   `,
   tags,
   request: {
@@ -113,7 +113,7 @@ export const updateStatus = createRoute({
   description: `
     Permite atualizar o status de uma despesa.
     Fluxo: PENDENTE -> APROVADO/REJEITADO (Coordenador/Admin).
-    Após aprovado, o Admin pode transicionar para EM_EDICAO (devolvendo ao aluno).
+    Admin pode transicionar APROVADO para EM_EDICAO (devolvendo ao aluno).
   `,
   tags,
   request: {

--- a/backend/src/services/expense.service.ts
+++ b/backend/src/services/expense.service.ts
@@ -2,7 +2,7 @@ import type { z } from '@hono/zod-openapi'
 import type { Prisma } from '@/generated/prisma/client'
 import type { CreateExpenseSchema, ExpenseListQuerySchema, UpdateExpenseSchema } from '@/schemas/expense.schema'
 import * as phrases from 'stoker/http-status-phrases'
-import { EXPENSE_ERROR_CODES, EXPENSE_STATUS_TRANSITIONS, STATUSES_WHERE_REASON_REQUIRED } from '@/constants/expense.constant'
+import { EXPENSE_ERROR_CODES, EXPENSE_STATUS_TRANSITIONS, EXPENSE_VISIBILITY_BY_ROLE, STATUSES_WHERE_REASON_REQUIRED } from '@/constants/expense.constant'
 import { MEMORANDUM_DOWNLOAD_URL_EXPIRY_SECONDS } from '@/constants/file.constant'
 import { PROJECT_ERROR_CODES } from '@/constants/project.constant'
 import { ExpenseRequestStatus } from '@/generated/prisma/client'
@@ -70,18 +70,15 @@ export async function getAllExpenseRequests(
   role: UserRole,
   filters: z.infer<typeof ExpenseListQuerySchema>,
 ) {
-  const where: Prisma.ExpenseRequestWhereInput = filters
+  const visibility: Prisma.ExpenseRequestWhereInput
+    = role === UserRole.ALUNO
+      ? { studentId: userId }
+      : { status: { in: EXPENSE_VISIBILITY_BY_ROLE[role] } }
 
-  if (role === UserRole.ALUNO) {
-    where.studentId = userId
-  }
-
-  const result = await prisma.expenseRequest.findMany({
-    where,
+  return prisma.expenseRequest.findMany({
+    where: { AND: [filters, visibility] },
     orderBy: { createdAt: 'desc' },
   })
-
-  return result
 }
 
 export async function getExpenseById(
@@ -94,13 +91,14 @@ export async function getExpenseById(
   if (role === UserRole.ALUNO) {
     where.studentId = userId
   }
+  else {
+    where.status = { in: EXPENSE_VISIBILITY_BY_ROLE[role] }
+  }
 
-  const result = await prisma.expenseRequest.findFirst({
+  return prisma.expenseRequest.findFirst({
     where,
     include: expenseInclude,
   })
-
-  return result
 }
 
 export async function updateExpenseStatus(
@@ -294,7 +292,7 @@ export async function updateExpense(
     where: { id },
     data: {
       ...data,
-      status: ExpenseRequestStatus.PENDENTE,
+      status: ExpenseRequestStatus.APROVADO,
       correctionReason: null,
     },
     include: expenseInclude,

--- a/backend/tests/integration/expenses/correction-flow.spec.ts
+++ b/backend/tests/integration/expenses/correction-flow.spec.ts
@@ -11,17 +11,22 @@ import { getAuthHeaders } from '../../util'
 
 const client = testClient(createTestApp(expenses))
 
-describe('[Expense Correction Flow] - Create → EM_EDICAO → Update → PENDENTE', () => {
+describe('[Expense Correction Flow] - Create → EM_EDICAO → Update → APROVADO → EM_PROCESSAMENTO', () => {
   let alunoHeaders: { Authorization: string }
   let adminHeaders: { Authorization: string }
   let coordenadorHeaders: { Authorization: string }
   let createdExpenseId: string
+  let projectId: string
   const correctionReason = 'Por favor, ajuste o título da despesa para condizer com o memorando.'
 
   beforeAll(async () => {
     await seedUsers()
     await seedExpenseCategories()
     await seedProjects()
+
+    const project = await prisma.project.findFirst()
+    assert(project)
+    projectId = project.id
 
     alunoHeaders = await getAuthHeaders('aluno@test.com', 'ALUNO')
     adminHeaders = await getAuthHeaders('admin@test.com', 'ADMIN')
@@ -56,7 +61,7 @@ describe('[Expense Correction Flow] - Create → EM_EDICAO → Update → PENDEN
     createdExpenseId = json.id
   })
 
-  it('[Step 2] Coordenador aprova a solicitação (necessário para posterior devolução)', async () => {
+  it('[Step 2] Coordenador aprova a solicitação', async () => {
     const endpoint = client.expenses[':id'].status.$patch
     const res = await endpoint(
       {
@@ -71,7 +76,7 @@ describe('[Expense Correction Flow] - Create → EM_EDICAO → Update → PENDEN
     expect(json.status).toBe(ExpenseRequestStatus.APROVADO)
   })
 
-  it('[Step 3] Coordenador tenta mover para EM_EDICAO (deve falhar - apenas ADMIN)', async () => {
+  it('[Step 2.1] Coordenador tenta mover para EM_EDICAO (deve falhar - apenas ADMIN)', async () => {
     const endpoint = client.expenses[':id'].status.$patch
     const res = await endpoint(
       {
@@ -87,7 +92,7 @@ describe('[Expense Correction Flow] - Create → EM_EDICAO → Update → PENDEN
     expect(res.status).toBe(status.FORBIDDEN)
   })
 
-  it('[Step 4] Admin move para EM_EDICAO com motivo', async () => {
+  it('[Step 3] Admin move para EM_EDICAO com motivo', async () => {
     const endpoint = client.expenses[':id'].status.$patch
     const res = await endpoint(
       {
@@ -107,7 +112,7 @@ describe('[Expense Correction Flow] - Create → EM_EDICAO → Update → PENDEN
     expect(json.correctionReason).toBe(correctionReason)
   })
 
-  it('[Step 4] Aluno tenta editar a despesa com dados válidos', async () => {
+  it('[Step 4] Aluno edita a despesa (status volta para APROVADO)', async () => {
     const updateData = { title: 'Título Corrigido - SBSC 2026' }
 
     const endpoint = client.expenses[':id'].$patch
@@ -122,23 +127,25 @@ describe('[Expense Correction Flow] - Create → EM_EDICAO → Update → PENDEN
     assert(res.status === status.OK)
     const json = await res.json()
 
-    expect(json.status).toBe(ExpenseRequestStatus.PENDENTE)
+    expect(json.status).toBe(ExpenseRequestStatus.APROVADO)
     expect(json.title).toBe(updateData.title)
     expect(json.correctionReason).toBeNull()
   })
 
-  it('[Step 5] Aluno tenta editar a despesa novamente (deve falhar - status é PENDENTE)', async () => {
-    const updateData = { title: 'Tentativa de Segunda Edição' }
-
-    const endpoint = client.expenses[':id'].$patch
+  it('[Step 5] Admin move para EM_PROCESSAMENTO (vínculo de projeto)', async () => {
+    const endpoint = client.expenses[':id']['assign-project'].$patch
     const res = await endpoint(
       {
         param: { id: createdExpenseId },
-        json: updateData,
+        json: { projectId },
       },
-      { headers: alunoHeaders },
+      { headers: adminHeaders },
     )
 
-    expect(res.status).toBe(status.CONFLICT)
+    assert(res.status === status.OK)
+    const json = await res.json()
+
+    expect(json.status).toBe(ExpenseRequestStatus.EM_PROCESSAMENTO)
+    expect(json.project?.id).toBe(projectId)
   })
 })

--- a/backend/tests/integration/expenses/visibility.spec.ts
+++ b/backend/tests/integration/expenses/visibility.spec.ts
@@ -1,0 +1,112 @@
+import { testClient } from 'hono/testing'
+import * as status from 'stoker/http-status-codes'
+import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest'
+import { ExpenseRequestStatus, UserRole } from '@/generated/prisma/enums'
+import { createTestApp } from '@/lib/config'
+import prisma from '@/lib/orm'
+import { expenses } from '@/routes'
+import { seedExpenseCategories, seedUsers } from '@/seeds'
+import { getAuthHeaders } from '../../util'
+
+const client = testClient(createTestApp(expenses))
+
+describe('[Expense Visibility] - Role-based isolation', () => {
+  let alunoHeaders: { Authorization: string }
+  let adminHeaders: { Authorization: string }
+  let coordenadorHeaders: { Authorization: string }
+  let alunoId: string
+
+  const createExpenseWithStatus = async (title: string, reqStatus: ExpenseRequestStatus) => {
+    return prisma.expenseRequest.create({
+      data: {
+        title,
+        status: reqStatus,
+        studentId: alunoId,
+        city: 'Test City',
+        state: 'BR-SP',
+        country: 'BR',
+        departureDate: new Date(),
+        returnDate: new Date(),
+      },
+    })
+  }
+
+  beforeAll(async () => {
+    await seedUsers()
+    await seedExpenseCategories()
+
+    const aluno = await prisma.user.findFirst({ where: { role: UserRole.ALUNO } })
+    alunoId = aluno!.id
+
+    alunoHeaders = await getAuthHeaders('aluno@test.com', 'ALUNO')
+    adminHeaders = await getAuthHeaders('admin@test.com', 'ADMIN')
+    coordenadorHeaders = await getAuthHeaders('coordenador@test.com', 'COORDENADOR')
+
+    await prisma.expenseRequest.deleteMany()
+
+    await createExpenseWithStatus('Pendente Test', ExpenseRequestStatus.PENDENTE)
+    await createExpenseWithStatus('Aprovado Test', ExpenseRequestStatus.APROVADO)
+    await createExpenseWithStatus('Rejeitado Test', ExpenseRequestStatus.REJEITADO)
+    await createExpenseWithStatus('Em Edicao Test', ExpenseRequestStatus.EM_EDICAO)
+    await createExpenseWithStatus('Em Processamento Test', ExpenseRequestStatus.EM_PROCESSAMENTO)
+  })
+
+  afterAll(async () => {
+    await prisma.expenseRequest.deleteMany()
+    await prisma.user.deleteMany()
+  })
+
+  it('[ALUNO] deve visualizar todos os seus próprios registros', async () => {
+    const res = await client.expenses.$get({ query: {} }, { headers: alunoHeaders })
+    expect(res.status).toBe(status.OK)
+    assert(res.status === status.OK)
+    const json = await res.json()
+    expect(json.length).toBe(5)
+  })
+
+  it('[COORDENADOR] deve visualizar apenas PENDENTE, APROVADO, REJEITADO', async () => {
+    const res = await client.expenses.$get({ query: {} }, { headers: coordenadorHeaders })
+    expect(res.status).toBe(status.OK)
+    assert(res.status === status.OK)
+
+    const json = await res.json()
+
+    const statuses = json.map(e => e.status)
+    expect(json.length).toBe(3)
+    expect(statuses).toContain(ExpenseRequestStatus.PENDENTE)
+    expect(statuses).toContain(ExpenseRequestStatus.APROVADO)
+    expect(statuses).toContain(ExpenseRequestStatus.REJEITADO)
+    expect(statuses).not.toContain(ExpenseRequestStatus.EM_EDICAO)
+    expect(statuses).not.toContain(ExpenseRequestStatus.EM_PROCESSAMENTO)
+  })
+
+  it('[ADMIN] deve visualizar APROVADO, EM_PROCESSAMENTO, EM_EDICAO', async () => {
+    const res = await client.expenses.$get({ query: {} }, { headers: adminHeaders })
+    expect(res.status).toBe(status.OK)
+    assert(res.status === status.OK)
+
+    const json = await res.json()
+
+    const statuses = json.map(e => e.status)
+    expect(json.length).toBe(3)
+    expect(statuses).toContain(ExpenseRequestStatus.APROVADO)
+    expect(statuses).toContain(ExpenseRequestStatus.EM_PROCESSAMENTO)
+    expect(statuses).toContain(ExpenseRequestStatus.EM_EDICAO)
+    expect(statuses).not.toContain(ExpenseRequestStatus.REJEITADO)
+    expect(statuses).not.toContain(ExpenseRequestStatus.PENDENTE)
+  })
+
+  it('[COORDENADOR] não deve conseguir acessar detalhes de EM_EDICAO via ID', async () => {
+    const emEdicao = await prisma.expenseRequest.findFirst({ where: { status: ExpenseRequestStatus.EM_EDICAO } })
+
+    const res = await client.expenses[':id'].$get({ param: { id: emEdicao!.id } }, { headers: coordenadorHeaders })
+    expect(res.status).toBe(status.NOT_FOUND)
+  })
+
+  it('[ADMIN] não deve conseguir acessar detalhes de PENDENTE via ID', async () => {
+    const pendente = await prisma.expenseRequest.findFirst({ where: { status: ExpenseRequestStatus.PENDENTE } })
+
+    const res = await client.expenses[':id'].$get({ param: { id: pendente!.id } }, { headers: adminHeaders })
+    expect(res.status).toBe(status.NOT_FOUND)
+  })
+})


### PR DESCRIPTION
Resumo do que foi feito:
   - Fluxo: Alterado EM_EDICAO para retornar a APROVADO (evitando re-aprovação do coordenador).
   - Visibilidade na listagem: 
       - Admin: Vê apenas APROVADO, EM_EDICAO e EM_PROCESSAMENTO.
       - Coordenador: Vê apenas PENDENTE, APROVADO e REJEITADO.
   - Analytics: Métricas de analytics permanecem inalteradas
   - Testes: Atualização dos testes de integração para refletir as alterações.