### PR TITLE
Feat/backend/expense conclusion

### DIFF
--- a/backend/prisma/migrations/20260514184352_add_concluido_expense_status/migration.sql
+++ b/backend/prisma/migrations/20260514184352_add_concluido_expense_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ExpenseRequestStatus" ADD VALUE 'CONCLUIDO';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -44,13 +44,13 @@ enum UserRole {
   COORDENADOR
   ADMIN
 }
-
 enum ExpenseRequestStatus {
   PENDENTE
   APROVADO
   REJEITADO
   EM_PROCESSAMENTO
   EM_EDICAO
+  CONCLUIDO
 }
 
 model ExpenseCategory {

--- a/backend/src/constants/expense.constant.ts
+++ b/backend/src/constants/expense.constant.ts
@@ -19,6 +19,7 @@ export const EXPENSE_STATUS_TRANSITIONS: Record<ExpenseRequestStatus, ExpenseReq
   ],
   [ExpenseRequestStatus.REJEITADO]: [],
   [ExpenseRequestStatus.EM_PROCESSAMENTO]: [],
+  [ExpenseRequestStatus.CONCLUIDO]: [],
 } as const
 
 export const EXPENSE_VISIBILITY_BY_ROLE: Record<UserRole, ExpenseRequestStatus[]> = {
@@ -32,6 +33,7 @@ export const EXPENSE_VISIBILITY_BY_ROLE: Record<UserRole, ExpenseRequestStatus[]
     ExpenseRequestStatus.APROVADO,
     ExpenseRequestStatus.EM_EDICAO,
     ExpenseRequestStatus.EM_PROCESSAMENTO,
+    ExpenseRequestStatus.CONCLUIDO,
   ],
 }
 
@@ -40,4 +42,6 @@ export const EXPENSE_ERROR_CODES = {
   RETURN_BEFORE_DEPARTURE: 'RETURN_DATE_BEFORE_DEPARTURE',
   STORAGE_NOT_CONFIGURED: 'STORAGE_NOT_CONFIGURED',
   MEMORANDUM_MISSING: 'MEMORANDUM_MISSING',
+  MISSING_BREAKDOWNS: 'MISSING_BREAKDOWNS',
+  MISSING_RECEIPTS: 'MISSING_RECEIPTS',
 } as const

--- a/backend/src/routes/expenses/expenses.handler.ts
+++ b/backend/src/routes/expenses/expenses.handler.ts
@@ -1,11 +1,11 @@
-import type { AssignProjectRoute, CreateRoute, GetMemorandumDownloadRoute, IndexRoute, ReadRoute, UpdateRoute, UpdateStatusRoute, UploadMemorandumRoute } from './expenses.route'
+import type { AssignProjectRoute, ConcludeRoute, CreateRoute, GetMemorandumDownloadRoute, IndexRoute, ReadRoute, UpdateRoute, UpdateStatusRoute, UploadMemorandumRoute } from './expenses.route'
 import type { AppRouteHandler } from '@/lib/type'
 import * as codes from 'stoker/http-status-codes'
 import * as phrases from 'stoker/http-status-phrases'
 import { EXPENSE_ERROR_CODES } from '@/constants/expense.constant'
 import { PROJECT_ERROR_CODES } from '@/constants/project.constant'
 import { AssignProjectResponseSchema, CreateExpenseResponseSchema, ExpenseResponseSchema, ListExpenseResponseSchema } from '@/schemas/expense.schema'
-import { assignProjectToExpense, attachMemorandumToExpense, createExpenseRequest, getAllExpenseRequests, getExpenseById, getMemorandumDownloadUrl, updateExpense, updateExpenseStatus } from '@/services/expense.service'
+import { assignProjectToExpense, attachMemorandumToExpense, concludeExpenseRequest, createExpenseRequest, getAllExpenseRequests, getExpenseById, getMemorandumDownloadUrl, updateExpense, updateExpenseStatus } from '@/services/expense.service'
 
 export const index: AppRouteHandler<IndexRoute> = async (c) => {
   const { sub, role } = c.get('jwtPayload')
@@ -216,4 +216,37 @@ export const getMemorandumDownload: AppRouteHandler<GetMemorandumDownloadRoute> 
     downloadUrl: result.url,
     expiresIn: result.expiresIn,
   }, codes.OK)
+}
+
+export const conclude: AppRouteHandler<ConcludeRoute> = async (c) => {
+  const { id } = c.req.valid('param')
+  const { role } = c.get('jwtPayload')
+
+  const result = await concludeExpenseRequest(id, role)
+
+  if ('error' in result) {
+    switch (result.error) {
+      case phrases.NOT_FOUND:
+        return c.json({ message: 'Despesa não encontrada' }, codes.NOT_FOUND)
+      case phrases.CONFLICT:
+        return c.json({ message: 'A solicitação não está no estado adequado para ser concluída' }, codes.CONFLICT)
+      case EXPENSE_ERROR_CODES.MISSING_BREAKDOWNS:
+        return c.json({ message: 'A solicitação não possui custos registrados' }, codes.BAD_REQUEST)
+      case EXPENSE_ERROR_CODES.MISSING_RECEIPTS:
+        return c.json({ message: 'Existem custos sem comprovantes anexados' }, codes.BAD_REQUEST)
+      default:
+        return c.json({ message: result.error }, codes.BAD_REQUEST)
+    }
+  }
+
+  const payload = {
+    ...result,
+    costBreakdowns: result.costBreakdowns?.map(cb => ({
+      ...cb,
+      subcategory: cb.expenseCategory,
+    })),
+  }
+
+  const parsed = ExpenseResponseSchema.parse(payload)
+  return c.json(parsed, codes.OK)
 }

--- a/backend/src/routes/expenses/expenses.route.ts
+++ b/backend/src/routes/expenses/expenses.route.ts
@@ -19,6 +19,7 @@ export type UpdateStatusRoute = typeof updateStatus
 export type AssignProjectRoute = typeof assignProject
 export type UploadMemorandumRoute = typeof uploadMemorandum
 export type GetMemorandumDownloadRoute = typeof getMemorandumDownload
+export type ConcludeRoute = typeof conclude
 
 const ALLOWED_ROLES: UserRole[] = ['ALUNO']
 
@@ -256,5 +257,40 @@ export const getMemorandumDownload = createRoute({
       'Variáveis R2 não configuradas.',
     ),
     [codes.UNAUTHORIZED]: UnauthorizedResponse,
+  },
+})
+
+export const conclude = createRoute({
+  path: '/{id}/conclude',
+  method: 'post',
+  middleware: [requireAuth, requireRole([UserRole.ADMIN])],
+  security: [{ bearerAuth: [] }],
+  summary: 'Conclude expense request',
+  description: `
+    Finaliza a solicitação de despesa, enviando formalmente os documentos ao aluno.
+    Exige que a despesa esteja 'EM_PROCESSAMENTO', tenha pelo menos um custo registrado e que TODOS os custos tenham comprovantes anexados.
+    Acesso restrito ao ADMIN.
+  `,
+  tags,
+  request: { params: z.object({ id: IdSchema }) },
+  responses: {
+    [codes.OK]: jsonContent(
+      ExpenseResponseSchema,
+      'Solicitação concluída com sucesso.',
+    ),
+    [codes.BAD_REQUEST]: jsonContent(
+      createMessageObjectSchema('Pendências encontradas'),
+      'A solicitação não possui custos registrados ou existem custos sem comprovantes.',
+    ),
+    [codes.CONFLICT]: jsonContent(
+      createMessageObjectSchema('Estado inválido'),
+      'A solicitação não está no estado adequado para ser concluída.',
+    ),
+    [codes.NOT_FOUND]: jsonContent(
+      createMessageObjectSchema('Despesa não encontrada'),
+      'ID inválido.',
+    ),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+    [codes.FORBIDDEN]: ForbiddenResponse,
   },
 })

--- a/backend/src/routes/expenses/index.ts
+++ b/backend/src/routes/expenses/index.ts
@@ -15,5 +15,6 @@ const router = createRouter().basePath('/expenses')
   .openapi(routes.getMemorandumDownload, handlers.getMemorandumDownload)
   .openapi(routes.updateStatus, handlers.updateStatus)
   .openapi(routes.assignProject, handlers.assignProject)
+  .openapi(routes.conclude, handlers.conclude)
 
 export default router

--- a/backend/src/services/analytics.service.ts
+++ b/backend/src/services/analytics.service.ts
@@ -20,7 +20,7 @@ export async function getAdminDashboardStats() {
   })
 
   const budgetCommitted = await prisma.project.aggregate({
-    where: { expenseRequests: { some: { status: { in: [ExpenseRequestStatus.APROVADO, ExpenseRequestStatus.EM_PROCESSAMENTO] } } } },
+    where: { expenseRequests: { some: { status: { in: [ExpenseRequestStatus.APROVADO, ExpenseRequestStatus.EM_PROCESSAMENTO, ExpenseRequestStatus.CONCLUIDO] } } } },
     _sum: { usedBudget: true },
   })
 
@@ -41,7 +41,7 @@ export async function getTopProjects(limit?: number) {
   const take = limit || DEFAULT_TOP_PROJECTS_COUNT
 
   const projects = await prisma.project.findMany({
-    where: { expenseRequests: { some: { status: { in: [ExpenseRequestStatus.APROVADO, ExpenseRequestStatus.EM_PROCESSAMENTO] } } } },
+    where: { expenseRequests: { some: { status: { in: [ExpenseRequestStatus.APROVADO, ExpenseRequestStatus.EM_PROCESSAMENTO, ExpenseRequestStatus.CONCLUIDO] } } } },
     select: {
       id: true,
       name: true,

--- a/backend/src/services/expense.service.ts
+++ b/backend/src/services/expense.service.ts
@@ -300,3 +300,42 @@ export async function updateExpense(
 
   return updatedRequest
 }
+
+export async function concludeExpenseRequest(
+  id: string,
+  userRole: UserRole,
+): Promise<ExpenseWithRelations | { error: string }> {
+  const expense = await prisma.expenseRequest.findUnique({
+    where: { id },
+    include: { costBreakdowns: true },
+  })
+
+  if (!expense) {
+    return { error: phrases.NOT_FOUND }
+  }
+
+  if (userRole !== UserRole.ADMIN) {
+    return { error: phrases.FORBIDDEN }
+  }
+
+  if (expense.status !== ExpenseRequestStatus.EM_PROCESSAMENTO) {
+    return { error: phrases.CONFLICT }
+  }
+
+  if (expense.costBreakdowns.length === 0) {
+    return { error: EXPENSE_ERROR_CODES.MISSING_BREAKDOWNS }
+  }
+
+  const missingReceipts = expense.costBreakdowns.some(cb => !cb.attachmentKey)
+  if (missingReceipts) {
+    return { error: EXPENSE_ERROR_CODES.MISSING_RECEIPTS }
+  }
+
+  const updatedExpense = await prisma.expenseRequest.update({
+    where: { id },
+    data: { status: ExpenseRequestStatus.CONCLUIDO },
+    include: expenseInclude,
+  })
+
+  return updatedExpense
+}

--- a/backend/tests/integration/expenses/conclusion-flow.spec.ts
+++ b/backend/tests/integration/expenses/conclusion-flow.spec.ts
@@ -1,0 +1,171 @@
+import { testClient } from 'hono/testing'
+import * as status from 'stoker/http-status-codes'
+import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest'
+import { ExpenseRequestStatus } from '@/generated/prisma/enums'
+import { createTestApp } from '@/lib/config'
+import prisma from '@/lib/orm'
+import { expenses } from '@/routes'
+import { seedExpenseCategories, seedUsers } from '@/seeds'
+import seedProjects from '@/seeds/project.seed'
+import { getAuthHeaders } from '../../util'
+
+const client = testClient(createTestApp(expenses))
+
+describe('[Expense Flow] - Ciclo de Conclusão de Despesa', () => {
+  let alunoHeaders: { Authorization: string }
+  let adminHeaders: { Authorization: string }
+  let coordenadorHeaders: { Authorization: string }
+  let projectId: string
+  let subcategoryName: string
+
+  beforeAll(async () => {
+    await seedUsers()
+    await seedExpenseCategories()
+    await seedProjects()
+
+    const project = await prisma.project.findFirst({ include: { expenseCategories: true } })
+    assert(project && project.expenseCategories.length > 0, 'Project or categories not found')
+    projectId = project.id
+    subcategoryName = project.expenseCategories[0]!.normalizedName
+
+    alunoHeaders = await getAuthHeaders('aluno@test.com', 'ALUNO')
+    adminHeaders = await getAuthHeaders('admin@test.com', 'ADMIN')
+    coordenadorHeaders = await getAuthHeaders('coordenador@test.com', 'COORDENADOR')
+  })
+
+  afterAll(async () => {
+    await prisma.costBreakdown.deleteMany()
+    await prisma.expenseRequest.deleteMany()
+    await prisma.project.deleteMany()
+    await prisma.expenseCategory.deleteMany()
+    await prisma.user.deleteMany()
+  })
+
+  it('[SUCESSO]: Fluxo completo de conclusão de despesa', async () => {
+    // 1. Aluno cria despesa
+    const createRes = await client.expenses.$post({
+      json: {
+        title: 'Viagem para Conclusão',
+        city: 'Manaus',
+        state: 'BR-AM',
+        country: 'BR',
+        departureDate: new Date('2026-07-01'),
+        returnDate: new Date('2026-07-05'),
+      },
+    }, { headers: alunoHeaders })
+    assert(createRes.status === status.CREATED)
+    const { id: expenseId } = await createRes.json()
+
+    // 2. Coordenador aprova
+    const approveRes = await client.expenses[':id'].status.$patch({
+      param: { id: expenseId },
+      json: { status: ExpenseRequestStatus.APROVADO },
+    }, { headers: coordenadorHeaders })
+    assert(approveRes.status === status.OK)
+
+    // 3. Admin vincula projeto (move para EM_PROCESSAMENTO)
+    const assignRes = await client.expenses[':id']['assign-project'].$patch({
+      param: { id: expenseId },
+      json: { projectId },
+    }, { headers: adminHeaders })
+    assert(assignRes.status === status.OK)
+
+    // 4. Tenta concluir sem breakdowns -> Deve falhar (BAD_REQUEST)
+    const concludeFail1 = await client.expenses[':id'].conclude.$post({ param: { id: expenseId } }, { headers: adminHeaders })
+    expect(concludeFail1.status).toBe(status.BAD_REQUEST)
+    assert(concludeFail1.status === status.BAD_REQUEST)
+
+    const err1 = await concludeFail1.json()
+    expect(err1.message).toContain('não possui custos registrados')
+    assert(err1.message.includes('não possui custos registrados'))
+
+    // 5. Adiciona breakdown sem comprovante
+    const breakdownRes = await client.expenses[':id']['cost-breakdowns'].$post({
+      param: { id: expenseId },
+      json: {
+        amount: 100,
+        subcategoryName,
+      },
+    }, { headers: adminHeaders })
+    assert(breakdownRes.status === status.CREATED)
+    const { id: breakdownId } = await breakdownRes.json()
+
+    // 6. Tenta concluir com breakdown sem comprovante -> Deve falhar (BAD_REQUEST)
+    const concludeFail2 = await client.expenses[':id'].conclude.$post({ param: { id: expenseId } }, { headers: adminHeaders })
+    expect(concludeFail2.status).toBe(status.BAD_REQUEST)
+    assert(concludeFail2.status === status.BAD_REQUEST)
+
+    const err2 = await concludeFail2.json()
+    expect(err2.message).toContain('custos sem comprovantes')
+    assert(err2.message.includes('custos sem comprovantes'))
+
+    // 7. Simula upload de comprovante via DB
+    await prisma.costBreakdown.update({
+      where: { id: breakdownId },
+      data: { attachmentKey: 'fake-key' },
+    })
+
+    // 8. Conclui com sucesso
+    const concludeSuccess = await client.expenses[':id'].conclude.$post({ param: { id: expenseId } }, { headers: adminHeaders })
+    expect(concludeSuccess.status).toBe(status.OK)
+    assert(concludeSuccess.status === status.OK)
+
+    const finalExpense = await concludeSuccess.json()
+    expect(finalExpense.status).toBe(ExpenseRequestStatus.CONCLUIDO)
+    assert(finalExpense.status === ExpenseRequestStatus.CONCLUIDO)
+  })
+
+  it('[PROIBIDO]: Apenas ADMIN pode concluir despesa', async () => {
+    const createRes = await client.expenses.$post({
+      json: {
+        title: 'Viagem Proibida',
+        city: 'Manaus',
+        state: 'BR-AM',
+        country: 'BR',
+        departureDate: new Date('2026-08-01'),
+        returnDate: new Date('2026-08-05'),
+      },
+    }, { headers: alunoHeaders })
+    assert(createRes.status === status.CREATED)
+    const { id: expenseId } = await createRes.json()
+
+    await client.expenses[':id'].status.$patch({
+      param: { id: expenseId },
+      json: { status: ExpenseRequestStatus.APROVADO },
+    }, { headers: coordenadorHeaders })
+
+    await client.expenses[':id']['assign-project'].$patch({
+      param: { id: expenseId },
+      json: { projectId },
+    }, { headers: adminHeaders })
+
+    // Tenta como Aluno
+    const resAluno = await client.expenses[':id'].conclude.$post({ param: { id: expenseId } }, { headers: alunoHeaders })
+    expect(resAluno.status).toBe(status.FORBIDDEN)
+    assert(resAluno.status === status.FORBIDDEN)
+
+    // Tenta como Coordenador
+    const resCoord = await client.expenses[':id'].conclude.$post({ param: { id: expenseId } }, { headers: coordenadorHeaders })
+    expect(resCoord.status).toBe(status.FORBIDDEN)
+    assert(resCoord.status === status.FORBIDDEN)
+  })
+
+  it('[CONFLITO]: Não pode concluir se não estiver em EM_PROCESSAMENTO', async () => {
+    const createRes = await client.expenses.$post({
+      json: {
+        title: 'Viagem Pendente',
+        city: 'Manaus',
+        state: 'BR-AM',
+        country: 'BR',
+        departureDate: new Date('2026-09-01'),
+        returnDate: new Date('2026-09-05'),
+      },
+    }, { headers: alunoHeaders })
+    assert(createRes.status === status.CREATED)
+    const { id: expenseId } = await createRes.json()
+
+    const res = await client.expenses[':id'].conclude.$post({ param: { id: expenseId } }, { headers: adminHeaders })
+    expect(res.status).toBe(status.CONFLICT)
+    assert(res.status === status.CONFLICT)
+  })
+})

--- a/testes/backend/analytics.service.test.ts
+++ b/testes/backend/analytics.service.test.ts
@@ -75,7 +75,7 @@ describe('analytics.service', () => {
       expenseRequests: {
         some: {
           status: {
-            in: [ExpenseRequestStatus.APROVADO, ExpenseRequestStatus.EM_PROCESSAMENTO],
+            in: [ExpenseRequestStatus.APROVADO, ExpenseRequestStatus.EM_PROCESSAMENTO, ExpenseRequestStatus.CONCLUIDO],
           },
         },
       },


### PR DESCRIPTION
## Why is this PR necessary, what does it do?
* Implementa o status `CONCLUIDO` para solicitações de despesa, permitindo o encerramento formal do fluxo pelo ADMIN.
* Adiciona validações rigorosas para a conclusão via endpoint:
  * A despesa deve estar obrigatoriamente em `EM_PROCESSAMENTO`.
  * Deve possuir ao menos um custo (cost breakdown) registrado.
  * Exige que TODOS os custos registrados possuam comprovantes anexados.
* Atualiza as regras de visibilidade e transição:
  * `CONCLUIDO` é um estado terminal da solicitação
  * ADMIN e ALUNO podem visualizar despesas concluídas.
* Ajusta o serviço de Analytics para incluir despesas concluídas 

Endpoints afetados:
* POST `/expenses/:id/conclude`
* GET `/expenses` (filtro de visibilidade atualizado)

## Notes
* Contribuição com testes: 
  * `backend/tests/integration/expenses/conclusion-flow.spec.ts`
* Se aprovado, permite habilitar as funcionalidades de visualização do portfólio de arquivos no frontend, por exemplo.