### PR TITLE
Feat/backend/expense report

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.939.0",
+        "@aws-sdk/lib-storage": "^3.939.0",
         "@aws-sdk/s3-request-presigner": "^3.939.0",
         "@hono/ajv-validator": "^0.0.2",
         "@hono/node-server": "^1.19.11",
@@ -34,6 +35,7 @@
         "i18n-iso-countries": "^7.14.0",
         "iso-3166-2": "^1.0.0",
         "nodemailer": "^8.0.7",
+        "pdfmake": "^0.3.9",
         "pg": "^8.20.0",
         "pg-boss": "^12.18.2",
         "stoker": "^2.0.1"
@@ -43,6 +45,7 @@
         "@testcontainers/postgresql": "^11.14.0",
         "@types/node": "^20.11.17",
         "@types/nodemailer": "^8.0.0",
+        "@types/pdfmake": "^0.2.11",
         "@types/pg": "^8.20.0",
         "@vitest/coverage-v8": "^4.1.3",
         "eslint": "^10.0.3",
@@ -675,6 +678,37 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.939.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.939.0.tgz",
+      "integrity": "sha512-PLpzeX2oA2i29MQ6h7CFN0QMuE3V8AF2kPtyHtd05lwBKcF5qJDriIUSIbvB56XEg/ceWYZaF5lAwSF7JkIitA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/smithy-client": "^4.9.8",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.939.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
@@ -2829,6 +2863,30 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -4511,6 +4569,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.15.tgz",
+      "integrity": "sha512-98zuTrdp06d5jhoIA7gBzEAh+4zZMywxdS1qiiUg0BOTq/EE4zc0bqgbSBKMcRKSNFZrpVFjspExiP7ScO2l5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
@@ -4987,9 +5058,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5258,6 +5329,15 @@
         "eslint": "^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.22.tgz",
+      "integrity": "sha512-/e2Ly3Docn9kYByap6TV4oquJ3wQuz3c+kC74riqtkwU9CwTMeuj6t2rW+bRr4pyOx/CYQM4wr0RgaKQwGEz0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@testcontainers/postgresql": {
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-11.14.0.tgz",
@@ -5389,6 +5469,27 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.6.tgz",
+      "integrity": "sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pdfmake": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@types/pdfmake/-/pdfmake-0.2.11.tgz",
+      "integrity": "sha512-gglgMQhnG6C2kco13DJlvokqTxL+XKxHwCejElH8fSCNF9ZCkRK6Mzo011jQ0zuug+YlIgn6BpcpZrARyWdW3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pdfkit": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -6617,6 +6718,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -7054,6 +7173,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -7468,6 +7596,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diacritics": {
       "version": "1.3.0",
@@ -8840,7 +8974,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -9211,6 +9344,23 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -9783,7 +9933,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9837,7 +9986,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
@@ -10033,6 +10181,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "10.0.0",
@@ -10474,6 +10628,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/local-pkg": {
@@ -12023,6 +12196,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-gitignore": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz",
@@ -12116,6 +12295,34 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pdfkit": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
+      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/pdfmake": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.3.9.tgz",
+      "integrity": "sha512-V8VIcjMG/yk7oJYhYjtvyLXvop3w3zcIB0bHdG3z1vuW8nVeemzRWu7YrOG7QA9KYaf858MZnCUG6hQ1Bei0vA==",
+      "license": "MIT",
+      "dependencies": {
+        "linebreak": "^1.1.0",
+        "pdfkit": "^0.18.0",
+        "xmldoc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -12353,6 +12560,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/pnpm-workspace-yaml": {
@@ -13059,6 +13274,12 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -13218,6 +13439,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -13573,6 +13803,30 @@
         }
       }
     },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
@@ -13589,7 +13843,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -13886,6 +14139,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -14229,6 +14488,32 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -14347,7 +14632,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -14876,6 +15160,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xmldoc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
+      "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/xtend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.939.0",
+    "@aws-sdk/lib-storage": "^3.939.0",
     "@aws-sdk/s3-request-presigner": "^3.939.0",
     "@hono/ajv-validator": "^0.0.2",
     "@hono/node-server": "^1.19.11",
@@ -49,6 +50,7 @@
     "i18n-iso-countries": "^7.14.0",
     "iso-3166-2": "^1.0.0",
     "nodemailer": "^8.0.7",
+    "pdfmake": "^0.3.9",
     "pg": "^8.20.0",
     "pg-boss": "^12.18.2",
     "stoker": "^2.0.1"
@@ -58,6 +60,7 @@
     "@testcontainers/postgresql": "^11.14.0",
     "@types/node": "^20.11.17",
     "@types/nodemailer": "^8.0.0",
+    "@types/pdfmake": "^0.2.11",
     "@types/pg": "^8.20.0",
     "@vitest/coverage-v8": "^4.1.3",
     "eslint": "^10.0.3",

--- a/backend/src/constants/expense.report.constant.ts
+++ b/backend/src/constants/expense.report.constant.ts
@@ -1,0 +1,40 @@
+export const GENERATE_REPORT_JOB_TYPE = 'generate-expense-report' as const
+
+export const REPORT_JOB_OPTIONS = {
+  retryLimit: 2,
+  retryDelay: 30,
+} as const
+
+export const REPORT_SSE_EVENTS = {
+  UPDATE: 'report-update',
+  FINISHED: 'report-finished',
+  ERROR: 'report-error',
+} as const
+
+export const REPORT_SSE_STATUS = {
+  NOT_FOUND: 'not_found',
+  COMPLETED: 'completed',
+  ERROR: 'error',
+  FAILED: 'failed',
+} as const
+
+export const REPORT_TRANSLATIONS = {
+  from: 'Data Inicial',
+  to: 'Data Final',
+  status: 'Status',
+  projectId: 'Projeto ID',
+  studentId: 'Aluno ID',
+} as const
+
+export const REPORT_PDF_CONFIG = {
+  MAX_RECORDS: 2000,
+  PAGE_ORIENTATION: 'landscape' as const,
+  CURRENCY: 'BRL',
+  LOCALE: 'pt-BR',
+  DATE_FORMAT: 'DD/MM/YYYY HH:mm',
+  FILTER_DATE_FORMAT: 'DD/MM/YYYY',
+  COLORS: {
+    SUBHEADER: '#666666',
+    TABLE_HEADER_FILL: '#f3f4f6',
+  },
+} as const

--- a/backend/src/jobs/generate-report.job.ts
+++ b/backend/src/jobs/generate-report.job.ts
@@ -1,0 +1,69 @@
+import type { z } from '@hono/zod-openapi'
+import type { Job } from 'pg-boss'
+import type { UserRole } from '@/generated/prisma/enums'
+import type { ExpenseReportQuerySchema } from '@/schemas/expense.schema'
+import { GENERATE_REPORT_JOB_TYPE, REPORT_JOB_OPTIONS } from '@/constants/expense.report.constant'
+import { BaseJob } from '@/lib/jobs'
+import { logger } from '@/lib/logger'
+import { generateExpenseReportPDF } from '@/lib/pdf-report'
+import { uploadStream } from '@/lib/storage'
+import { getReportViewModel } from '@/services/reports'
+
+export type GenerateReportJobData = {
+  userId: string
+  role: UserRole
+  query: z.infer<typeof ExpenseReportQuerySchema>
+}
+
+export type GenerateReportJobOutput = {
+  fileKey: string
+}
+
+export class GenerateReportJob extends BaseJob<GenerateReportJobData, GenerateReportJobOutput> {
+  readonly type = GENERATE_REPORT_JOB_TYPE
+
+  override readonly options = REPORT_JOB_OPTIONS
+
+  async work(job: Job<GenerateReportJobData>): Promise<GenerateReportJobOutput> {
+    const { userId, role, query } = job.data
+
+    logger.info({
+      jobId: job.id,
+      userId,
+      query,
+    }, 'Processing expense report generation job')
+
+    try {
+      const viewModel = await getReportViewModel(userId, role, query)
+
+      const pdfDoc = await generateExpenseReportPDF(viewModel, query)
+
+      const fileName = `report-${job.id}.pdf`
+
+      const uploadPromise = uploadStream({
+        stream: pdfDoc,
+        fileName,
+        contentType: 'application/pdf',
+        folder: 'reports',
+      })
+
+      pdfDoc.end()
+
+      const uploadResult = await uploadPromise
+
+      logger.info({
+        jobId: job.id,
+        fileKey: uploadResult.fileKey,
+      }, 'Expense report generated and uploaded successfully')
+
+      return { fileKey: uploadResult.fileKey }
+    }
+    catch (error) {
+      logger.error({
+        err: error,
+        jobId: job.id,
+      }, 'Failed to generate expense report in worker')
+      throw error
+    }
+  }
+}

--- a/backend/src/jobs/index.ts
+++ b/backend/src/jobs/index.ts
@@ -1,5 +1,7 @@
 import { boss, JobManager } from '@/lib/jobs'
+import { GenerateReportJob } from './generate-report.job'
 import { SendEmailJob } from './send-email.job'
 
 export const jobManager = new JobManager(boss)
   .register(new SendEmailJob(boss))
+  .register(new GenerateReportJob(boss))

--- a/backend/src/jobs/send-email.job.ts
+++ b/backend/src/jobs/send-email.job.ts
@@ -11,7 +11,7 @@ export type EmailJobData = {
   requestId?: string
 } & SendEmailInput
 
-export class SendEmailJob extends BaseJob<EmailJobData> {
+export class SendEmailJob extends BaseJob<EmailJobData, void> {
   readonly type = 'send-email' as const
 
   override readonly options = {

--- a/backend/src/json/expense-request/event/event.schema.json
+++ b/backend/src/json/expense-request/event/event.schema.json
@@ -12,7 +12,8 @@
     "location": { 
       "type": "string",
       "minLength": 3,
-      "title": "Localização do Evento"
+      "title": "Localização do Evento",
+      "x-report": true
     }
   },
   "required": [

--- a/backend/src/json/preference-survey/preference-survey.schema.json
+++ b/backend/src/json/preference-survey/preference-survey.schema.json
@@ -27,23 +27,27 @@
         "departureDate": { 
           "type": "string", 
           "format": "date", 
-          "title": "Data Ida" 
+          "title": "Data Ida",
+          "x-report": true
         },
         "returnDate": { 
           "type": "string", 
           "format": "date", 
           "title": "Data Volta",
+          "x-report": true,
           "dateAfter": { 
             "$data": "1/departureDate" 
           } 
         },
         "departureRoute": { 
           "type": "string", 
-          "title": "Trecho Ida" 
+          "title": "Trecho Ida",
+          "x-report": true
         },
         "returnRoute": { 
           "type": "string", 
-          "title": "Trecho Volta" 
+          "title": "Trecho Volta",
+          "x-report": true
         },
         "flightSuggestionKey": { 
           "type": "string", 

--- a/backend/src/lib/jobs.ts
+++ b/backend/src/lib/jobs.ts
@@ -1,4 +1,4 @@
-import type { Job, SendOptions, WorkOptions } from 'pg-boss'
+import type { Job, JobWithMetadata, SendOptions, WorkOptions } from 'pg-boss'
 import type { Prisma } from '@/generated/prisma/client'
 import { fromPrisma, PgBoss } from 'pg-boss'
 import env from '@/env'
@@ -21,7 +21,7 @@ boss.on('warning', (warning) => {
 
 export type EmitOptions = SendOptions & { tx?: Prisma.TransactionClient }
 
-export abstract class BaseJob<T extends object = object> {
+export abstract class BaseJob<TData extends object = object, TOutput = unknown> {
   abstract readonly type: string
 
   readonly options: SendOptions = {
@@ -35,16 +35,14 @@ export abstract class BaseJob<T extends object = object> {
 
   async start(): Promise<void> {
     await this.boss.work(this.type, this.workOptions ?? {}, async (jobs) => {
-      const jobArray = Array.isArray(jobs) ? jobs : [jobs]
-      for (const job of jobArray) {
-        await this.work(job as Job<T>)
-      }
+      const results = await Promise.all(jobs.map(job => this.work(job as Job<TData>)))
+      return jobs.length === 1 ? results[0] : results
     })
   }
 
-  abstract work(job: Job<T>): Promise<void>
+  abstract work(job: Job<TData>): Promise<TOutput>
 
-  async emit(data: T, options?: EmitOptions): Promise<void> {
+  async emit(data: TData, options?: EmitOptions): Promise<void> {
     const { tx, ...sendOptions } = options || {}
 
     await this.boss.send(this.type, data, {
@@ -55,16 +53,26 @@ export abstract class BaseJob<T extends object = object> {
   }
 }
 
-export class JobManager<TMapping extends Record<string, any> = Record<string, never>> {
-  private jobsMap = new Map<string, BaseJob<any>>()
+export class JobManager<TMapping extends Record<string, { req: any, res: any }> = Record<string, never>> {
+  private jobsMap = new Map<string, BaseJob<any, any>>()
 
   constructor(public readonly boss: PgBoss) {}
 
-  register<TType extends string, TData extends object>(
-    job: BaseJob<TData> & { type: TType },
-  ): JobManager<TMapping & { [K in TType]: TData }> {
+  register<TType extends string, TData extends object, TOutput>(
+    job: BaseJob<TData, TOutput> & { type: TType },
+  ): JobManager<TMapping & { [K in TType]: { req: TData, res: TOutput } }> {
     this.jobsMap.set(job.type, job)
     return this as any
+  }
+
+  getWorker<K extends keyof TMapping & string>(
+    type: K,
+  ): BaseJob<TMapping[K]['req'], TMapping[K]['res']> {
+    const worker = this.jobsMap.get(type)
+    if (!worker) {
+      throw new Error(`Worker for job type "${type}" not found.`)
+    }
+    return worker as BaseJob<TMapping[K]['req'], TMapping[K]['res']>
   }
 
   async start(): Promise<void> {
@@ -81,7 +89,7 @@ export class JobManager<TMapping extends Record<string, any> = Record<string, ne
 
   async emit<K extends keyof TMapping & string>(
     type: K,
-    data: TMapping[K],
+    data: TMapping[K]['req'],
     options?: EmitOptions,
   ): Promise<void> {
     const job = this.jobsMap.get(type)
@@ -89,5 +97,21 @@ export class JobManager<TMapping extends Record<string, any> = Record<string, ne
       throw new Error(`Job ${type} not registered`)
     }
     await job.emit(data, options)
+  }
+
+  async getJob<K extends keyof TMapping & string>(
+    type: K,
+    jobId: string,
+  ): Promise<(JobWithMetadata<TMapping[K]['req']> & { output: TMapping[K]['res'] | null }) | null> {
+    const [job] = await this.boss.findJobs<TMapping[K]['req']>(type, { id: jobId })
+    return (job as any) || null
+  }
+
+  async completeJob<K extends keyof TMapping & string>(
+    type: K,
+    jobId: string,
+    data: TMapping[K]['res'],
+  ): Promise<void> {
+    await this.boss.complete(type, jobId, data as object)
   }
 }

--- a/backend/src/lib/pdf-report.ts
+++ b/backend/src/lib/pdf-report.ts
@@ -1,0 +1,306 @@
+import type { Content, TableCell, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces'
+import type { ReportAnalytics, ReportRow, ReportViewModel } from '@/services/reports'
+import pdfmake from 'pdfmake'
+import { REPORT_PDF_CONFIG, REPORT_TRANSLATIONS } from '@/constants/expense.report.constant'
+import { formatCurrency } from '@/services/reports'
+import { dayjs } from './date'
+
+const fonts: TFontDictionary = {
+  Roboto: {
+    normal: 'node_modules/pdfmake/fonts/Roboto/Roboto-Regular.ttf',
+    bold: 'node_modules/pdfmake/fonts/Roboto/Roboto-Medium.ttf',
+    italics: 'node_modules/pdfmake/fonts/Roboto/Roboto-Italic.ttf',
+    bolditalics: 'node_modules/pdfmake/fonts/Roboto/Roboto-MediumItalic.ttf',
+  },
+}
+
+// @ts-expect-error - pdfmake singleton might have different types in 0.3.x
+const pdfInstance = (pdfmake.default || pdfmake)
+pdfInstance.setFonts(fonts)
+
+export async function generateExpenseReportPDF(
+  viewModel: ReportViewModel,
+  filters: Record<string, unknown>,
+) {
+  const { rows, analytics } = viewModel
+
+  const docDefinition: TDocumentDefinitions = {
+    content: [
+      {
+        text: 'Relatório de Despesas',
+        style: 'header',
+      },
+      {
+        text: `Gerado em: ${dayjs().format(REPORT_PDF_CONFIG.DATE_FORMAT)}`,
+        style: 'subheader',
+      },
+
+      renderFilters(filters),
+      renderAnalyticsCards(analytics),
+
+      {
+        text: 'Detalhamento das Solicitações',
+        style: 'sectionTitle',
+        margin: [0, 20, 0, 10],
+      },
+
+      renderTable(rows),
+    ],
+    styles: {
+      header: {
+        fontSize: 18,
+        bold: true,
+        margin: [0, 0, 0, 5],
+      },
+      subheader: {
+        fontSize: 10,
+        italics: true,
+        margin: [0, 0, 0, 15],
+        color: REPORT_PDF_CONFIG.COLORS.SUBHEADER,
+      },
+      sectionTitle: {
+        fontSize: 12,
+        bold: true,
+        color: '#333333',
+      },
+      filterSection: { margin: [0, 0, 0, 15] },
+      filterTitle: {
+        fontSize: 10,
+        bold: true,
+      },
+
+      cardTitle: {
+        fontSize: 9,
+        color: '#666666',
+        bold: true,
+      },
+      cardValue: {
+        fontSize: 14,
+        bold: true,
+        color: '#2563eb',
+      },
+
+      tableHeader: {
+        fontSize: 10,
+        bold: true,
+        fillColor: REPORT_PDF_CONFIG.COLORS.TABLE_HEADER_FILL,
+        margin: [5, 5, 5, 5],
+      },
+      tableCell: {
+        fontSize: 9,
+        margin: [5, 5, 5, 5],
+      },
+
+      costCategory: {
+        fontSize: 8,
+        color: '#444444',
+      },
+      costAmount: {
+        fontSize: 8,
+        alignment: 'right',
+      },
+      costTotal: {
+        fontSize: 9,
+        bold: true,
+        alignment: 'right',
+        margin: [0, 2, 0, 0],
+      },
+    },
+    defaultStyle: { font: 'Roboto' },
+    pageOrientation: REPORT_PDF_CONFIG.PAGE_ORIENTATION,
+  }
+
+  const doc = pdfInstance.createPdf(docDefinition)
+  return doc.getStream()
+}
+
+function renderAnalyticsCards(analytics: ReportAnalytics): Content {
+  const topCategories = Object.entries(analytics.byCategory)
+    .sort((a, b) => b[1].comparedTo(a[1]))
+    .slice(0, 3)
+    .map(([name, total]) => `${name}: ${formatCurrency(total)}`)
+    .join('\n')
+
+  return {
+    columns: [
+      {
+        stack: [
+          {
+            text: 'TOTAL GASTO',
+            style: 'cardTitle',
+          },
+          {
+            text: formatCurrency(analytics.totalAmount),
+            style: 'cardValue',
+          },
+        ],
+        width: '*',
+      },
+      {
+        stack: [
+          {
+            text: 'SOLICITAÇÕES',
+            style: 'cardTitle',
+          },
+          {
+            text: String(analytics.totalRequests),
+            style: 'cardValue',
+          },
+        ],
+        width: '*',
+      },
+      {
+        stack: [
+          {
+            text: 'MAIORES GASTOS',
+            style: 'cardTitle',
+          },
+          {
+            text: topCategories || 'N/A',
+            style: 'tableCell',
+            margin: [0, 2, 0, 0],
+          },
+        ],
+        width: '*',
+      },
+    ],
+    margin: [0, 0, 0, 20],
+    columnGap: 10,
+  }
+}
+
+function renderFilters(filters: Record<string, unknown>): Content {
+  const filterEntries = Object.entries(filters)
+    .filter(([_, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => {
+      let displayValue = String(value)
+      if (value instanceof Date)
+        displayValue = dayjs(value).format(REPORT_PDF_CONFIG.FILTER_DATE_FORMAT)
+      return {
+        text: [{
+          text: `${translateFilterKey(key)}: `,
+          bold: true,
+        }, displayValue],
+      }
+    })
+
+  if (filterEntries.length === 0) {
+    return {
+      text: 'Filtros: Nenhum',
+      style: 'filterSection',
+    }
+  }
+
+  return {
+    stack: [
+      {
+        text: 'Filtros aplicados:',
+        style: 'filterTitle',
+      },
+      {
+        ul: filterEntries,
+        margin: [0, 5, 0, 0],
+      },
+    ],
+    style: 'filterSection',
+  }
+}
+
+function translateFilterKey(key: string) {
+  return (REPORT_TRANSLATIONS as any)[key] || key
+}
+
+function renderTable(rows: ReportRow[]): Content {
+  const body: TableCell[][] = [
+    [
+      {
+        text: 'Aluno',
+        style: 'tableHeader',
+      },
+      {
+        text: 'Destino',
+        style: 'tableHeader',
+      },
+      {
+        text: 'Período',
+        style: 'tableHeader',
+      },
+      {
+        text: 'Projeto',
+        style: 'tableHeader',
+      },
+      {
+        text: 'Composição do Gasto',
+        style: 'tableHeader',
+        alignment: 'right',
+      },
+      {
+        text: 'Status',
+        style: 'tableHeader',
+      },
+    ],
+    ...rows.map(row => [
+      {
+        text: row.studentName,
+        style: 'tableCell',
+      },
+      {
+        text: row.destination,
+        style: 'tableCell',
+      },
+      {
+        text: row.period,
+        style: 'tableCell',
+      },
+      {
+        text: row.projectCode,
+        style: 'tableCell',
+      },
+      {
+        stack: [
+          ...row.breakdown.map(item => ({
+            columns: [
+              {
+                text: item.category,
+                style: 'costCategory',
+              },
+              {
+                text: item.amountDisplay,
+                style: 'costAmount',
+              },
+            ],
+          })),
+          {
+            canvas: [{
+              type: 'line',
+              x1: 0,
+              y1: 2,
+              x2: 100,
+              y2: 2,
+              lineWidth: 0.5,
+              lineColor: '#eeeeee',
+            }],
+          },
+          {
+            text: row.totalDisplay,
+            style: 'costTotal',
+          },
+        ],
+        margin: [0, 2, 0, 2],
+      } as TableCell,
+      {
+        text: row.status,
+        style: 'tableCell',
+      },
+    ]),
+  ]
+
+  return {
+    table: {
+      headerRows: 1,
+      widths: ['auto', '*', 'auto', 'auto', 'auto', 'auto'],
+      body,
+    },
+    layout: 'lightHorizontalLines',
+  }
+}

--- a/backend/src/lib/storage.ts
+++ b/backend/src/lib/storage.ts
@@ -1,5 +1,7 @@
+import type { Readable } from 'node:stream'
 import crypto from 'node:crypto'
 import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { FILENAME_SANITIZE_REGEX } from '@/constants/file.constant'
 import env from '@/env'
@@ -34,15 +36,23 @@ function getClient(): S3Client {
 export type UploadFileOptions = {
   file: File
   contentType: string
-  folder: 'memorandos' | 'comprovantes' | 'formulario-preferencias'
+  folder: 'memorandos' | 'comprovantes' | 'formulario-preferencias' | 'reports'
   subfolder?: string
   prefix?: string
+}
+
+export type UploadStreamOptions = {
+  stream: Readable
+  fileName: string
+  contentType: string
+  folder: 'reports'
+  subfolder?: string
 }
 
 export type UploadFileResult = {
   fileKey: string
   fileName: string
-  fileSize: number
+  fileSize?: number
 }
 
 export async function uploadFile(options: UploadFileOptions): Promise<UploadFileResult> {
@@ -67,6 +77,32 @@ export async function uploadFile(options: UploadFileOptions): Promise<UploadFile
     fileKey,
     fileName: sanitizedFileName,
     fileSize: file.size,
+  }
+}
+
+export async function uploadStream(options: UploadStreamOptions): Promise<UploadFileResult> {
+  const { stream, fileName, contentType, folder, subfolder } = options
+  const uniqueId = crypto.randomUUID()
+  const sanitizedFileName = fileName.replace(FILENAME_SANITIZE_REGEX, '_')
+
+  const path = subfolder ? `${folder}/${subfolder}` : folder
+  const fileKey = `${path}/${uniqueId}-${sanitizedFileName}`
+
+  const upload = new Upload({
+    client: getClient(),
+    params: {
+      Bucket: env.R2_BUCKET_NAME!,
+      Key: fileKey,
+      Body: stream,
+      ContentType: contentType,
+    },
+  })
+
+  await upload.done()
+
+  return {
+    fileKey,
+    fileName: sanitizedFileName,
   }
 }
 

--- a/backend/src/lib/util.ts
+++ b/backend/src/lib/util.ts
@@ -1,6 +1,5 @@
-import type { z } from '@hono/zod-openapi'
 import type { AppContext, AppOpenAPI } from './type'
-import { OpenAPIHono } from '@hono/zod-openapi'
+import { OpenAPIHono, z } from '@hono/zod-openapi'
 import { defaultHook } from 'stoker/openapi'
 
 export function createRouter() {
@@ -28,12 +27,27 @@ export function multipartFormContentRequired<
   }
 }
 
-/**
- * Gera uma data ISO relativa ao "agora" para evitar que seeds e mocks expirem.
- * @param daysOffset - Dias para somar (ex: 2) ou subtrair (ex: -5).
- * @param hours - Hora do dia fixa (0-23). Padrão: 9.
- * @returns Data no padrão ISO 8601.
- */
+export function sseContent<
+  T extends z.ZodTypeAny,
+  E extends z.ZodTypeAny = z.ZodString,
+>(
+  dataSchema: T,
+  description: string,
+  eventSchema: E = z.string() as unknown as E,
+) {
+  return {
+    content: {
+      'text/event-stream': {
+        schema: z.object({
+          event: eventSchema.openapi({ description: 'Nome do evento SSE' }),
+          data: dataSchema.openapi({ description: 'Payload JSON do evento' }),
+        }),
+      },
+    },
+    description,
+  }
+}
+
 export function getRelativeDate(daysOffset: number, hours: number = 9): string {
   const date = new Date()
   date.setDate(date.getDate() + daysOffset)

--- a/backend/src/routes/expenses/index.ts
+++ b/backend/src/routes/expenses/index.ts
@@ -4,11 +4,13 @@ import costBreakdowns from './cost-breakdowns'
 import * as handlers from './expenses.handler'
 import * as routes from './expenses.route'
 import forms from './forms'
+import reports from './reports'
 
 const router = createRouter().basePath('/expenses')
   .route('/', categories)
   .route('/', costBreakdowns)
   .route('/', forms)
+  .route('/', reports)
   .openapi(routes.index, handlers.index)
   .openapi(routes.create, handlers.create)
   .openapi(routes.read, handlers.read)

--- a/backend/src/routes/expenses/reports/index.ts
+++ b/backend/src/routes/expenses/reports/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/util'
+import * as handlers from './reports.handler'
+import * as routes from './reports.route'
+
+const router = createRouter().basePath('/reports')
+  .openapi(routes.requestReport, handlers.requestReport)
+  .openapi(routes.reportStatus, handlers.reportStatus)
+
+export default router

--- a/backend/src/routes/expenses/reports/reports.handler.ts
+++ b/backend/src/routes/expenses/reports/reports.handler.ts
@@ -1,0 +1,98 @@
+import type { ReportStatusRoute, RequestReportRoute } from './reports.route'
+import type { AppRouteHandler } from '@/lib/type'
+import { streamSSE } from 'hono/streaming'
+import * as codes from 'stoker/http-status-codes'
+import { GENERATE_REPORT_JOB_TYPE, REPORT_SSE_EVENTS, REPORT_SSE_STATUS } from '@/constants/expense.report.constant'
+import { UserRole } from '@/generated/prisma/enums'
+import { jobManager } from '@/jobs'
+import { getSignedDownloadUrl } from '@/lib/storage'
+import { ReportEventDataSchema, ReportEventEnumSchema } from '@/schemas/report.schema'
+
+export const requestReport: AppRouteHandler<RequestReportRoute> = async (c) => {
+  const { sub, role } = c.get('jwtPayload')
+  const query = c.req.valid('query')
+
+  const jobId = await jobManager.boss.send(GENERATE_REPORT_JOB_TYPE, {
+    userId: sub,
+    role,
+    query,
+  })
+
+  return c.json({ jobId: jobId! }, codes.ACCEPTED)
+}
+
+export const reportStatus: AppRouteHandler<ReportStatusRoute> = async (c) => {
+  const { jobId } = c.req.valid('param')
+  const { sub, role } = c.get('jwtPayload')
+
+  return streamSSE(c, async (sse) => {
+    let completed = false
+    sse.onAbort(() => {
+      completed = true
+    })
+
+    while (!completed) {
+      const job = await jobManager.getJob(GENERATE_REPORT_JOB_TYPE, jobId)
+
+      if (!job || (job.data.userId !== sub && role !== UserRole.ADMIN)) {
+        await sse.writeSSE({
+          data: JSON.stringify(ReportEventDataSchema.parse({ status: REPORT_SSE_STATUS.NOT_FOUND })),
+          event: ReportEventEnumSchema.parse(REPORT_SSE_EVENTS.ERROR),
+        })
+        break
+      }
+
+      switch (job.state) {
+        case 'completed': {
+          const output = job.output
+          if (output?.fileKey) {
+            const downloadUrl = await getSignedDownloadUrl(output.fileKey)
+            await sse.writeSSE({
+              data: JSON.stringify(ReportEventDataSchema.parse({
+                status: REPORT_SSE_STATUS.COMPLETED,
+                downloadUrl,
+              })),
+              event: ReportEventEnumSchema.parse(REPORT_SSE_EVENTS.FINISHED),
+            })
+          }
+          else {
+            await sse.writeSSE({
+              data: JSON.stringify(ReportEventDataSchema.parse({
+                status: REPORT_SSE_STATUS.ERROR,
+                message: 'Missing file key',
+              })),
+              event: ReportEventEnumSchema.parse(REPORT_SSE_EVENTS.ERROR),
+            })
+          }
+          completed = true
+          break
+        }
+        case 'failed': {
+          const message = typeof job.output === 'string'
+            ? job.output
+            : (job.output as any)?.message || 'Erro interno no processamento'
+
+          await sse.writeSSE({
+            data: JSON.stringify(ReportEventDataSchema.parse({
+              status: REPORT_SSE_STATUS.FAILED,
+              message,
+            })),
+            event: ReportEventEnumSchema.parse(REPORT_SSE_EVENTS.ERROR),
+          })
+          completed = true
+          break
+        }
+        case 'active':
+        case 'created':
+        case 'retry':
+        default: {
+          await sse.writeSSE({
+            data: JSON.stringify(ReportEventDataSchema.parse({ status: job.state })),
+            event: ReportEventEnumSchema.parse(REPORT_SSE_EVENTS.UPDATE),
+          })
+          await new Promise(resolve => setTimeout(resolve, 2000))
+        }
+      }
+    }
+  })
+}

--- a/backend/src/routes/expenses/reports/reports.route.ts
+++ b/backend/src/routes/expenses/reports/reports.route.ts
@@ -1,0 +1,50 @@
+import { createRoute, z } from '@hono/zod-openapi'
+import * as codes from 'stoker/http-status-codes'
+import { jsonContent } from 'stoker/openapi/helpers'
+import { sseContent } from '@/lib/util'
+import { requireAuth } from '@/middlewares'
+import { ExpenseReportQuerySchema } from '@/schemas/expense.schema'
+import { ReportEventDataSchema, ReportEventEnumSchema } from '@/schemas/report.schema'
+import { IdSchema, UnauthorizedResponse } from '@/schemas/shared.schema'
+
+const tags = ['Expenses - Reports']
+
+export type RequestReportRoute = typeof requestReport
+export type ReportStatusRoute = typeof reportStatus
+
+export const requestReport = createRoute({
+  path: '/',
+  method: 'get',
+  tags,
+  middleware: [requireAuth],
+  security: [{ bearerAuth: [] }],
+  summary: 'Request expense report generation',
+  description: 'Inicia a geração assíncrona do relatório PDF e retorna um jobId.',
+  request: { query: ExpenseReportQuerySchema },
+  responses: {
+    [codes.ACCEPTED]: jsonContent(
+      z.object({ jobId: z.string().uuid() }),
+      'Geração de relatório iniciada.',
+    ),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+  },
+})
+
+export const reportStatus = createRoute({
+  path: '/status/{jobId}',
+  method: 'get',
+  tags,
+  middleware: [requireAuth],
+  security: [{ bearerAuth: [] }],
+  summary: 'Monitor report generation status (SSE)',
+  description: 'Acompanha o progresso da geração via Server-Sent Events. Envia eventos nomeados como `report-update`, `report-finished` e `report-error`.',
+  request: { params: z.object({ jobId: IdSchema }) },
+  responses: {
+    [codes.OK]: sseContent(
+      ReportEventDataSchema,
+      'Stream de eventos SSE. Utilize addEventListener para capturar os eventos específicos.',
+      ReportEventEnumSchema,
+    ),
+    [codes.UNAUTHORIZED]: UnauthorizedResponse,
+  },
+})

--- a/backend/src/schemas/expense.schema.ts
+++ b/backend/src/schemas/expense.schema.ts
@@ -136,3 +136,23 @@ export const UpdateExpenseSchema = BaseSchema
     surveyAnswers: z.array(PreferenceSurveyAnswerSchema).min(1, { message: 'Selecione pelo menos uma preferência para continuar.' })
       .optional(),
   })
+
+export const ExpenseReportQuerySchema = z.object({
+  from: z.coerce.date().optional()
+    .openapi({
+      description: 'Data inicial para filtro (createdAt)',
+      example: '2026-01-01T00:00:00Z',
+    }),
+  to: z.coerce.date().optional()
+    .openapi({
+      description: 'Data final para filtro (createdAt)',
+      example: '2026-12-31T23:59:59Z',
+    }),
+  status: z.enum(ExpenseRequestStatus).optional()
+    .openapi({
+      description: 'Filtrar por status',
+      example: ExpenseRequestStatus.APROVADO,
+    }),
+  projectId: IdSchema.optional().openapi({ description: 'Filtrar por projeto' }),
+  studentId: IdSchema.optional().openapi({ description: 'Filtrar por aluno' }),
+})

--- a/backend/src/schemas/report.schema.ts
+++ b/backend/src/schemas/report.schema.ts
@@ -1,0 +1,29 @@
+import { z } from '@hono/zod-openapi'
+import { REPORT_SSE_EVENTS, REPORT_SSE_STATUS } from '@/constants/expense.report.constant'
+
+export const ReportEventEnumSchema = z.enum([
+  REPORT_SSE_EVENTS.UPDATE,
+  REPORT_SSE_EVENTS.FINISHED,
+  REPORT_SSE_EVENTS.ERROR,
+])
+
+export const ReportEventDataSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal(REPORT_SSE_STATUS.COMPLETED),
+    downloadUrl: z.string().url()
+      .openapi({ example: 'https://storage.example.com/reports/abc-123.pdf?token=...' }),
+  }),
+  z.object({
+    status: z.literal(REPORT_SSE_STATUS.ERROR),
+    message: z.string().openapi({ example: 'Erro inesperado na conexão' }),
+  }),
+  z.object({
+    status: z.literal(REPORT_SSE_STATUS.FAILED),
+    message: z.string().optional()
+      .openapi({ example: 'Ocorreu um erro interno no processamento' }),
+  }),
+  z.object({ status: z.literal(REPORT_SSE_STATUS.NOT_FOUND) }),
+  z.object({ status: z.enum(['active', 'created', 'retry', 'waiting', 'cancelled']) }),
+])
+
+export type ReportSSEEvent = z.infer<typeof ReportEventDataSchema>

--- a/backend/src/services/expense.service.ts
+++ b/backend/src/services/expense.service.ts
@@ -51,6 +51,7 @@ export const expenseInclude = {
       id: true,
       data: true,
       surveyId: true,
+      survey: { select: { schema: true } },
     },
   },
 } satisfies Prisma.ExpenseRequestInclude

--- a/backend/src/services/reports/index.ts
+++ b/backend/src/services/reports/index.ts
@@ -1,0 +1,3 @@
+export * from './report-analytics.logic'
+export * from './report-data.service'
+export * from './report-formatter.logic'

--- a/backend/src/services/reports/report-analytics.logic.ts
+++ b/backend/src/services/reports/report-analytics.logic.ts
@@ -1,0 +1,66 @@
+import type { ExpenseWithRelations } from '@/services/expense.service'
+import { Prisma } from '@/generated/prisma/client'
+
+export type ProjectAnalytics = {
+  projectCode: string
+  projectName: string
+  total: Prisma.Decimal
+  requestCount: number
+}
+
+export type ReportAnalytics = {
+  totalAmount: Prisma.Decimal
+  totalRequests: number
+  byCategory: Record<string, Prisma.Decimal>
+  byProject: Record<string, ProjectAnalytics>
+}
+
+export function calculateReportAnalytics(expenses: ExpenseWithRelations[]): ReportAnalytics {
+  const analytics: ReportAnalytics = {
+    totalAmount: new Prisma.Decimal(0),
+    totalRequests: expenses.length,
+    byCategory: {},
+    byProject: {},
+  }
+
+  for (const expense of expenses) {
+    const projectKey = expense.projectId || 'unassigned'
+
+    if (!analytics.byProject[projectKey]) {
+      analytics.byProject[projectKey] = {
+        projectCode: expense.project?.code || 'N/A',
+        projectName: expense.project?.name || 'Não Atribuído',
+        total: new Prisma.Decimal(0),
+        requestCount: 0,
+      }
+    }
+
+    const projectStats = analytics.byProject[projectKey]
+    projectStats.requestCount++
+
+    for (const cb of expense.costBreakdowns) {
+      const amount = cb.amount
+      const categoryName = cb.expenseCategory.name
+
+      analytics.totalAmount = analytics.totalAmount.add(amount)
+
+      if (!analytics.byCategory[categoryName]) {
+        analytics.byCategory[categoryName] = new Prisma.Decimal(0)
+      }
+      analytics.byCategory[categoryName] = analytics.byCategory[categoryName].add(amount)
+
+      projectStats.total = projectStats.total.add(amount)
+    }
+  }
+
+  return analytics
+}
+
+export function getTopExpenseCategories(
+  categoryTotals: Record<string, Prisma.Decimal>,
+  limit: number = 3,
+): [categoryName: string, total: Prisma.Decimal][] {
+  return Object.entries(categoryTotals)
+    .sort(([_nameA, amountA], [_nameB, amountB]) => amountB.comparedTo(amountA))
+    .slice(0, limit)
+}

--- a/backend/src/services/reports/report-data.service.ts
+++ b/backend/src/services/reports/report-data.service.ts
@@ -1,0 +1,103 @@
+import type { z } from '@hono/zod-openapi'
+import type { ExpenseWithRelations } from '../expense.service'
+import type { ReportAnalytics } from './report-analytics.logic'
+import type { ExtractedReportInfo } from './report-formatter.logic'
+import type { ExpenseReportQuerySchema } from '@/schemas/expense.schema'
+import { EXPENSE_VISIBILITY_BY_ROLE } from '@/constants/expense.constant'
+import { REPORT_PDF_CONFIG } from '@/constants/expense.report.constant'
+import { Prisma } from '@/generated/prisma/client'
+import { UserRole } from '@/generated/prisma/enums'
+import prisma from '@/lib/orm'
+import { expenseInclude } from '../expense.service'
+import { calculateReportAnalytics } from './report-analytics.logic'
+import { extractTripInfo, formatCurrency } from './report-formatter.logic'
+
+export type ReportRow = {
+  id: string
+  studentName: string
+  projectName: string
+  projectCode: string
+  status: string
+  totalRaw: Prisma.Decimal
+  totalDisplay: string
+  breakdown: {
+    category: string
+    amountDisplay: string
+  }[]
+} & ExtractedReportInfo
+
+export type ReportViewModel = {
+  rows: ReportRow[]
+  analytics: ReportAnalytics
+  isTruncated: boolean
+}
+
+export async function getReportViewModel(
+  userId: string,
+  role: UserRole,
+  query: z.infer<typeof ExpenseReportQuerySchema>,
+): Promise<ReportViewModel> {
+  const { from, to, status, projectId, studentId } = query
+
+  const visibility = role === UserRole.ALUNO
+    ? { studentId: userId }
+    : { status: { in: EXPENSE_VISIBILITY_BY_ROLE[role] } }
+
+  const filters: any = {}
+  if (from || to) {
+    filters.createdAt = {
+      ...(from && { gte: from }),
+      ...(to && { lte: to }),
+    }
+  }
+
+  if (status)
+    filters.status = status
+  if (projectId)
+    filters.projectId = projectId
+  if (studentId && role !== UserRole.ALUNO) {
+    filters.studentId = studentId
+  }
+
+  const expenses = await prisma.expenseRequest.findMany({
+    where: { AND: [filters, visibility] },
+    include: expenseInclude,
+    orderBy: { createdAt: 'desc' },
+    take: REPORT_PDF_CONFIG.MAX_RECORDS,
+  })
+
+  // Transforma os dados em ViewModel mantendo a precisão Decimal
+  const rows: ReportRow[] = expenses.map(expense => transformToReportRow(expense))
+  const analytics = calculateReportAnalytics(expenses)
+
+  return {
+    rows,
+    analytics,
+    isTruncated: expenses.length === REPORT_PDF_CONFIG.MAX_RECORDS,
+  }
+}
+
+function transformToReportRow(expense: ExpenseWithRelations): ReportRow {
+  const tripInfo = extractTripInfo(expense)
+
+  const totalRaw = expense.costBreakdowns.reduce(
+    (acc, cb) => acc.add(cb.amount),
+    new Prisma.Decimal(0),
+  )
+
+  return {
+    id: expense.id,
+    studentName: expense.student?.name || 'N/A',
+    projectName: expense.project?.name || 'Não Atribuído',
+    projectCode: expense.project?.code || 'N/A',
+    status: expense.status,
+    destination: tripInfo.destination,
+    period: tripInfo.period,
+    totalRaw,
+    totalDisplay: formatCurrency(totalRaw),
+    breakdown: expense.costBreakdowns.map(cb => ({
+      category: cb.expenseCategory.name,
+      amountDisplay: formatCurrency(cb.amount),
+    })),
+  }
+}

--- a/backend/src/services/reports/report-formatter.logic.ts
+++ b/backend/src/services/reports/report-formatter.logic.ts
@@ -1,0 +1,108 @@
+import type { Prisma } from '@/generated/prisma/client'
+import type { ExpenseWithRelations } from '@/services/expense.service'
+import { REPORT_PDF_CONFIG } from '@/constants/expense.report.constant'
+import { eventJSONSchema } from '@/json'
+import { dayjs } from '@/lib/date'
+
+export type ReportSchemaProperty = {
+  'type'?: string
+  'format'?: string
+  'x-report'?: boolean
+  [key: string]: unknown
+}
+
+export type ReportSchema = {
+  properties?: Record<string, ReportSchemaProperty>
+  [key: string]: unknown
+}
+
+export type ExtractedReportInfo = {
+  destination: string
+  period: string
+}
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}/
+
+export function formatCurrency(value: number | Prisma.Decimal): string {
+  const amount = typeof value === 'number' ? value : value.toNumber()
+
+  return new Intl.NumberFormat(REPORT_PDF_CONFIG.LOCALE, {
+    style: 'currency',
+    currency: REPORT_PDF_CONFIG.CURRENCY,
+  }).format(amount)
+}
+
+export function extractTripInfo(expense: ExpenseWithRelations): ExtractedReportInfo {
+  const allTexts: string[] = []
+  const allDates: string[] = []
+
+  for (const answer of expense.surveyAnswers) {
+    const schema = answer.survey.schema as unknown as ReportSchema
+    const data = answer.data as Prisma.JsonObject
+    const { texts, dates } = extractFromSchema(schema, data)
+
+    allTexts.push(...texts)
+    allDates.push(...dates)
+  }
+
+  if (allTexts.length > 0 || allDates.length > 0) {
+    const uniqueTexts = Array.from(new Set(allTexts))
+
+    return {
+      destination: uniqueTexts.join(' - ') || 'N/A',
+      period: formatPeriod(allDates),
+    }
+  }
+
+  // 3. Fallback: Se nenhuma preferência tinha marcação x-report, usa o Evento
+  const eventData = expense.event as Prisma.JsonObject
+  const eventExtracted = extractFromSchema(eventJSONSchema as unknown as ReportSchema, eventData)
+
+  return {
+    destination: eventExtracted.texts.join(' - ') || 'N/A',
+    period: dayjs(expense.createdAt).format(REPORT_PDF_CONFIG.FILTER_DATE_FORMAT),
+  }
+}
+
+export function extractFromSchema(schema: ReportSchema, data: Prisma.JsonObject | null) {
+  const texts: string[] = []
+  const dates: string[] = []
+
+  if (!schema?.properties || !data) {
+    return {
+      texts,
+      dates,
+    }
+  }
+
+  for (const key of Object.keys(schema.properties)) {
+    const prop = schema.properties[key]
+    const value = data[key]
+
+    if (prop && prop['x-report'] && value !== undefined && value !== null) {
+      const stringValue = String(value)
+      const isDate = prop.format === 'date' || DATE_REGEX.test(stringValue)
+
+      if (isDate)
+        dates.push(stringValue)
+      else texts.push(stringValue)
+    }
+  }
+
+  return {
+    texts,
+    dates,
+  }
+}
+
+export function formatPeriod(dates: string[]): string {
+  if (dates.length === 0)
+    return 'N/A'
+
+  const uniqueDates = Array.from(new Set(dates))
+
+  return uniqueDates
+    .sort((a, b) => dayjs(a).valueOf() - dayjs(b).valueOf())
+    .map(d => dayjs(d).format(REPORT_PDF_CONFIG.FILTER_DATE_FORMAT))
+    .join(' - ')
+}

--- a/backend/tests/integration/expenses/reports.spec.ts
+++ b/backend/tests/integration/expenses/reports.spec.ts
@@ -14,25 +14,18 @@ import { seedExpenseCategories, seedExpenses, seedPreferenceSurveys, seedProject
 import { getReportViewModel } from '@/services/reports'
 import { getAuthHeaders } from '../../util'
 
-vi.mock('@aws-sdk/client-s3', () => {
+vi.mock('@/lib/storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/storage')>()
   return {
-    S3Client: class {
-      send = vi.fn().mockResolvedValue({})
-    },
-    PutObjectCommand: class { constructor(public input: any) {} },
-    GetObjectCommand: class { constructor(public input: any) {} },
-    DeleteObjectCommand: class { constructor(public input: any) {} },
+    ...actual,
+    isStorageConfigured: vi.fn().mockReturnValue(true),
+    uploadStream: vi.fn().mockResolvedValue({
+      fileKey: 'reports/mock-file.pdf',
+      fileName: 'mock-file.pdf',
+    }),
+    getSignedDownloadUrl: vi.fn().mockResolvedValue('http://signed.url/report.pdf'),
   }
 })
-
-vi.mock('@aws-sdk/lib-storage', () => ({
-  Upload: class {
-    constructor() {}
-    done = vi.fn().mockResolvedValue({})
-  },
-}))
-
-vi.mock('@aws-sdk/s3-request-presigner', () => ({ getSignedUrl: vi.fn().mockResolvedValue('http://signed.url/report.pdf') }))
 
 const app = createTestApp(expenses)
 const client = testClient(app)
@@ -117,8 +110,7 @@ describe('[Expense Reports Flow] Integration Tests', () => {
       expect(typeof result.fileKey).toBe('string')
       expect(result.fileKey.length).toBeGreaterThan(0)
 
-      // O storage adiciona um prefixo UUID, então verificamos apenas o final do caminho
-      expect(result.fileKey).toMatch(/reports\/.*-report-test-job-id\.pdf$/)
+      expect(result.fileKey).toBe('reports/mock-file.pdf')
     })
   })
 

--- a/backend/tests/integration/expenses/reports.spec.ts
+++ b/backend/tests/integration/expenses/reports.spec.ts
@@ -1,0 +1,218 @@
+import type { Job, JobWithMetadata } from 'pg-boss'
+import type { Mock } from 'vitest'
+import type { GenerateReportJobData, GenerateReportJobOutput } from '@/jobs/generate-report.job'
+import { testClient } from 'hono/testing'
+import * as status from 'stoker/http-status-codes'
+import { afterAll, afterEach, assert, beforeAll, describe, expect, it, vi } from 'vitest'
+import { GENERATE_REPORT_JOB_TYPE, REPORT_SSE_EVENTS, REPORT_SSE_STATUS } from '@/constants/expense.report.constant'
+import { ID_ALUNO, ID_PROJ_ROBOTICA } from '@/constants/seed.constant'
+import { UserRole } from '@/generated/prisma/enums'
+import { jobManager } from '@/jobs'
+import { createTestApp } from '@/lib/config'
+import { expenses } from '@/routes'
+import { seedExpenseCategories, seedExpenses, seedPreferenceSurveys, seedProjects, seedUsers } from '@/seeds'
+import { getReportViewModel } from '@/services/reports'
+import { getAuthHeaders } from '../../util'
+
+vi.mock('@aws-sdk/client-s3', () => {
+  return {
+    S3Client: class {
+      send = vi.fn().mockResolvedValue({})
+    },
+    PutObjectCommand: class { constructor(public input: any) {} },
+    GetObjectCommand: class { constructor(public input: any) {} },
+    DeleteObjectCommand: class { constructor(public input: any) {} },
+  }
+})
+
+vi.mock('@aws-sdk/lib-storage', () => ({
+  Upload: class {
+    constructor() {}
+    done = vi.fn().mockResolvedValue({})
+  },
+}))
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({ getSignedUrl: vi.fn().mockResolvedValue('http://signed.url/report.pdf') }))
+
+const app = createTestApp(expenses)
+const client = testClient(app)
+
+type ReportJobWithMetadata = JobWithMetadata<GenerateReportJobData> & { output: GenerateReportJobOutput | null }
+
+describe('[Expense Reports Flow] Integration Tests', () => {
+  let adminHeaders: { Authorization: string }
+  let studentHeaders: { Authorization: string }
+  const endpoint = client.expenses.reports
+
+  beforeAll(async () => {
+    await seedUsers()
+    await seedExpenseCategories()
+    await seedProjects()
+    await seedPreferenceSurveys()
+    await seedExpenses()
+
+    adminHeaders = await getAuthHeaders('admin@test.com', 'ADMIN')
+    studentHeaders = await getAuthHeaders('aluno@test.com', 'ALUNO')
+
+    await jobManager.start()
+  })
+
+  afterEach(async () => {
+    jobManager.boss.clearSpies()
+    vi.restoreAllMocks()
+  })
+
+  afterAll(async () => {
+    await jobManager.stop()
+  })
+
+  describe('2.2.1 API Ingestão', () => {
+    it('deve retornar 202 Accepted, jobId e passar filtros corretamente para o job', async () => {
+      const spy = jobManager.boss.getSpy<GenerateReportJobData>(GENERATE_REPORT_JOB_TYPE)
+      const query = {
+        status: 'APROVADO',
+        projectId: ID_PROJ_ROBOTICA,
+      } as const
+
+      const res = await endpoint.$get(
+        { query },
+        { headers: adminHeaders },
+      )
+
+      expect(res.status).toBe(status.ACCEPTED)
+      assert(res.status === status.ACCEPTED)
+
+      const json = await res.json()
+      expect(json).toHaveProperty('jobId')
+
+      const job = await spy.waitForJob(data => data.query.status === query.status, 'created')
+      expect(job).toBeDefined()
+      assert(job)
+      expect(job.data.query.projectId).toBe(query.projectId)
+      expect(job.data.role).toBe(UserRole.ADMIN)
+    })
+  })
+
+  describe('2.2.2 Background Worker', () => {
+    it('deve simular a execução do job, gerar PDF e fazer upload', async () => {
+      const jobInstance = jobManager.getWorker(GENERATE_REPORT_JOB_TYPE)
+
+      const fakeJobData: GenerateReportJobData = {
+        userId: ID_ALUNO,
+        role: UserRole.ALUNO,
+        query: {},
+      }
+
+      const fakeJob = {
+        id: 'test-job-id',
+        data: fakeJobData,
+      } as unknown as Job<GenerateReportJobData>
+
+      const result = await jobInstance.work(fakeJob)
+
+      // Verifica se o resultado é um objeto e contém o fileKey
+      expect(result).toBeDefined()
+      expect(result).not.toBeInstanceOf(Array)
+      expect(result).toHaveProperty('fileKey')
+      expect(typeof result.fileKey).toBe('string')
+      expect(result.fileKey.length).toBeGreaterThan(0)
+
+      // O storage adiciona um prefixo UUID, então verificamos apenas o final do caminho
+      expect(result.fileKey).toMatch(/reports\/.*-report-test-job-id\.pdf$/)
+    })
+  })
+
+  describe('2.2.3 SSE (Server-Side Events)', () => {
+    it('deve monitorar o status e receber o evento final com a URL de download', async () => {
+      const jobId = '3659c0bd-34e2-4195-9e4a-f64105904e0a'
+
+      // Mockamos o getJob para retornar concluído imediatamente com tipagem rigorosa
+      ;(vi.spyOn(jobManager, 'getJob') as Mock).mockResolvedValue({
+        id: jobId,
+        state: 'completed',
+        data: {
+          userId: ID_ALUNO,
+          role: UserRole.ALUNO,
+          query: {},
+        },
+        output: { fileKey: 'reports/final-report.pdf' },
+      } as unknown as ReportJobWithMetadata)
+
+      const res = await app.request(`/expenses/reports/status/${jobId}`, { headers: studentHeaders })
+
+      expect(res.status).toBe(status.OK)
+      expect(res.headers.get('content-type')).toContain('text/event-stream')
+
+      const reader = res.body?.getReader()
+      assert(reader)
+
+      const { value } = await reader.read()
+      const chunk = new TextDecoder().decode(value)
+
+      expect(chunk).toContain(REPORT_SSE_EVENTS.FINISHED)
+      expect(chunk).toContain('http://signed.url/report.pdf')
+    })
+
+    it('deve propagar mensagem de erro quando o job falha', async () => {
+      const jobId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+      ;(vi.spyOn(jobManager, 'getJob') as Mock).mockResolvedValue({
+        id: jobId,
+        state: 'failed',
+        data: {
+          userId: ID_ALUNO,
+          role: UserRole.ALUNO,
+          query: {},
+        },
+        output: { message: 'Erro de cota excedida' },
+      } as unknown as ReportJobWithMetadata)
+
+      const res = await app.request(`/expenses/reports/status/${jobId}`, { headers: studentHeaders })
+      const reader = res.body?.getReader()
+      assert(reader)
+
+      const { value } = await reader.read()
+      const chunk = new TextDecoder().decode(value)
+
+      expect(chunk).toContain(REPORT_SSE_STATUS.FAILED)
+      expect(chunk).toContain('Erro de cota excedida')
+    })
+  })
+
+  describe('2.3 Segurança e Autorização', () => {
+    it('acesso ao Status: Aluno não deve conseguir monitorar job de outro usuário', async () => {
+      const jobId = '400e8b62-b32f-40b6-93e1-445cb09f24bc'
+
+      ;(vi.spyOn(jobManager, 'getJob') as Mock).mockResolvedValue({
+        id: jobId,
+        state: 'active',
+        data: {
+          userId: 'another-user-uuid',
+          role: UserRole.ALUNO,
+          query: {},
+        },
+        output: null,
+      } as unknown as ReportJobWithMetadata)
+
+      const res = await app.request(`/expenses/reports/status/${jobId}`, { headers: studentHeaders })
+
+      const reader = res.body?.getReader()
+      assert(reader)
+      const { value } = await reader.read()
+      const chunk = new TextDecoder().decode(value)
+
+      expect(chunk).toContain(REPORT_SSE_STATUS.NOT_FOUND)
+    })
+
+    it('visibilidade de Dados: Relatório do Aluno deve conter apenas suas próprias despesas', async () => {
+      const viewModel = await getReportViewModel(ID_ALUNO, UserRole.ALUNO, {})
+
+      viewModel.rows.forEach((row) => {
+        expect(row.studentName).toBe('Codibentinho')
+      })
+
+      const adminViewModel = await getReportViewModel('admin-id', UserRole.ADMIN, {})
+      expect(adminViewModel.rows).toBeInstanceOf(Array)
+    })
+  })
+})

--- a/docs/planning/PLAN_async_report_generation.md
+++ b/docs/planning/PLAN_async_report_generation.md
@@ -1,0 +1,59 @@
+# Guia Técnico: Relatórios Assíncronos (PDF)
+
+Este módulo gerencia a exportação relatórios de despesas em formato PDF, utilizando processamento em segundo plano e monitoramento via Server-Sent Events (SSE).
+
+## 💡 O Conceito
+*   **Problema**:
+    1.  **Bloqueio do Event Loop**: A geração de PDF é intensiva em CPU. Processá-la de forma síncrona na requisição HTTP tornaria a API indisponível para outros usuários.
+    2.  **Esgotamento de Memória (OOM)**: Carregar milhares de registros simultaneamente para gerar um documento derrubaria o container por falta de RAM.
+    3.  **Feedback Ineficiente**: Processos pesados geram incerteza sobre o tempo de conclusão. Fazer polling (consultas repetitivas) para checar o status sobrecarrega o banco de dados.
+
+*   **Proposta**: 
+    1.  **Background Jobs**: Desacoplamento via `pg-boss`, o pedido é delegado ao a um worker isolado, que processa a fila de acordo com a capacidade.
+    2.  **Streaming & Limites**: Limite máximo de **2.000 registros** e upload via Stream ao storage R2, sem manter o arquivo completo na memória.
+    3.  **Comunicação Unidirecional (SSE)**: O servidor envia atualizações de status e o link final para o frontend à medida que o worker avança, mantendo uma única conexão de texto contínua.
+
+*   **Benefícios**:
+    *   **Estabilidade**: O Event Loop do Node.js permanece livre.
+    *   **Escalabilidade**: Uso previsível de memória RAM.
+    *   **Previsibilidade**: O usuário recebe feedback sobre o andamento do processo.
+
+
+## 🏗️ Guia de Desenvolvimento
+
+### 1. Iniciar Geração
+**GET** | `/expenses/reports` | Registra o pedido de relatório com filtros opcionais.
+
+*   **Query Params**: `userId`, `projectId`, `status`, `from`, `to`.
+*   **Retorno**: `{ "jobId": "uuid-do-job" }`
+
+### 2. Monitorar via SSE
+**GET** | `/expenses/reports/status/{jobId}` | Canal de texto para acompanhar o progresso.
+
+Recomenda-se o uso de `addEventListener` para escutar os eventos específicos. Os dados chegam como texto e devem ser desserializados:
+
+*   **`report-update`**: Atualizações de estado do job (`created`, `active`).
+*   **`report-finished`**: Sucesso. Retorna os dados com o `downloadUrl`.
+*   **`report-error`**: Falha. Retorna os dados com a `message` do erro.
+
+```javascript
+const sse = new EventSource(`/v1/expenses/reports/status/${jobId}`);
+
+// Sucesso: Redireciona para o download
+sse.addEventListener('report-finished', (e) => {
+  const payload = JSON.parse(e.data); // Desserializa o texto para objeto
+  window.location.href = payload.downloadUrl;
+  sse.close();
+});
+
+// Erro: Notifica o usuário
+sse.addEventListener('report-error', (e) => {
+  const payload = JSON.parse(e.data);
+  console.error("Falha no relatório:", payload.message);
+  sse.close();
+});
+```
+
+## 🎯 Detalhes Técnicos
+*   **Namespacing**: Todos os eventos seguem o padrão `report-*` para evitar colisões globais no frontend.
+*   **Documentação**: Uso do helper `sseContent` para garantir que o OpenAPI reflita a estrutura de texto `event` + `data` do protocolo real, evitando a confusão com respostas JSON tradicionais.

--- a/testes/backend/package-lock.json
+++ b/testes/backend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "testes-backend",
       "version": "1.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1056.0",
+        "@aws-sdk/lib-storage": "^3.1056.0",
+        "@aws-sdk/s3-request-presigner": "^3.1056.0",
         "@hono/zod-openapi": "^1.2.3",
         "@prisma/adapter-pg": "^7.6.0",
         "@prisma/client": "^7.6.0",
@@ -25,6 +28,7 @@
         "i18n-iso-countries": "^7.14.0",
         "iso-3166-2": "^1.0.0",
         "nodemailer": "^8.0.7",
+        "pdfmake": "^0.3.9",
         "pg": "^8.20.0",
         "pg-boss": "^12.18.2",
         "pino": "^10.3.1",
@@ -34,6 +38,7 @@
       "devDependencies": {
         "@types/iso-3166-2": "^1.0.4",
         "@types/node": "^20.11.17",
+        "@types/pdfmake": "^0.3.3",
         "@vitest/coverage-v8": "^4.1.3",
         "pino-pretty": "^13.1.3",
         "typescript": "^5.8.3",
@@ -50,6 +55,537 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1056.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1056.0.tgz",
+      "integrity": "sha512-WfMZEM2eC96anIT0RzR/QmhaefWKsNjOHNv09ORBkcA++ULBnm1fRau+KKGEIbr5nDnf9BTG7E7U3oOVklQS8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.46",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.17",
+        "@aws-sdk/middleware-expect-continue": "^3.972.14",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.23",
+        "@aws-sdk/middleware-location-constraint": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.44",
+        "@aws-sdk/middleware-ssec": "^3.972.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.15.tgz",
+      "integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.5",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
+      "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
+      "integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
+      "integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.45.tgz",
+      "integrity": "sha512-sJe5ZWibO4s7RWjFQ8Zol76KxoJcIYyEZH1/wxQSBMSIAAxzaJ8cS/ITAaIHWUQvDKQdt18+cJAHKWB7n1Jmrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-login": "^3.972.45",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
+      "integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.46.tgz",
+      "integrity": "sha512-cS4w0jzDRb1jOlkiJS3y80OxddHzkky/MN9k3NYs5jganNKVLjF0lpvjlwS118oGMr3cdAfOlVdo8gLurTSE7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-ini": "^3.972.45",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
+      "integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
+      "integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/token-providers": "3.1056.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
+      "integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.1056.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1056.0.tgz",
+      "integrity": "sha512-+Gg4n2/1RVyREDiI53VlUYSjXg1g70uhhujojnUqwH1FyQ8bTFPZ23zJNdNAU5QCIAusgNkqhZS03fVk2bXCRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.1056.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.17.tgz",
+      "integrity": "sha512-lbDmWuHenc+kiwCNrxz4MyN6nkxCWyTXPIWuspJN0ibziu+8CXci7vI1bK9MAkwy8cwJOEXNu0gBM5S0uTGRIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.14.tgz",
+      "integrity": "sha512-3TNFEVGO4sWZj9TEXOCZLzGEctXHnaO4fk2EQ8KVaboTbwHmEPEQrm17Xb9koImUIXEw0sgi2xtHjg7LuTS3rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.23.tgz",
+      "integrity": "sha512-4nPKARo2lfKvQGUt2fPA5NlS/mEohckdxpuC9ecbjVfj7B7NFFYHeTg+Bf5BEQwdn3yRfUIzFiEkPp8Yuaw3wA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/crc64-nvme": "^3.972.9",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
+      "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.44.tgz",
+      "integrity": "sha512-8HQsRg1NpX8vR4vNl1E8pyLnqZroq9VSL2vZQVSgBqp6wv6365LzYD08/c9FFh/9FTg7YRc7aTtEmXF0ir/pqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
+      "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
+      "integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1056.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1056.0.tgz",
+      "integrity": "sha512-bRqvWgjfJOLakgsmcXgUnTCrTep1B9ppCUjsUyu0M7ueRnVjcNc2uZox/bneCKOgjbzQG7Hs8bo+lTotRdOVOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
+      "integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1056.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
+      "integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
+      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -220,6 +756,42 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
@@ -558,12 +1130,141 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@smithy/core": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
+      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.5.tgz",
+      "integrity": "sha512-yiF8xHpdkaTfzLVqFzsP6WvNghEK+qZzLYWFD13L2SsFhbXwBGlxdocKF95qjr7s5lE5NRage+EJFK4mAsx88Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
+      "integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
+      "integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
+      "integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -615,6 +1316,27 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.6.tgz",
+      "integrity": "sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pdfmake": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/pdfmake/-/pdfmake-0.3.3.tgz",
+      "integrity": "sha512-ufbceB4Q3dKpmFUMKEbZvJcfLi8+C5b1+rTFVG6urtkS3FHwaTQH6NCh/iEEDINlApCxH/W3/rsq99pP5E9/JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pdfkit": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -892,6 +1614,40 @@
         "node": "*"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -935,6 +1691,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/colorette": {
@@ -1057,6 +1822,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diacritics": {
       "version": "1.3.0",
@@ -1183,6 +1954,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1235,6 +2015,43 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1274,6 +2091,23 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -1542,6 +2376,32 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/iso-3166-2": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/iso-3166-2/-/iso-3166-2-1.0.0.tgz",
@@ -1595,6 +2455,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "10.0.0",
@@ -1900,6 +2766,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -2101,12 +2986,61 @@
         "yaml": "^2.8.0"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfkit": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
+      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/pdfmake": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.3.9.tgz",
+      "integrity": "sha512-V8VIcjMG/yk7oJYhYjtvyLXvop3w3zcIB0bHdG3z1vuW8nVeemzRWu7YrOG7QA9KYaf858MZnCUG6hQ1Bei0vA==",
+      "license": "MIT",
+      "dependencies": {
+        "linebreak": "^1.1.0",
+        "pdfkit": "^0.18.0",
+        "xmldoc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/pg": {
       "version": "8.20.0",
@@ -2305,6 +3239,14 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -2421,6 +3363,20 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -2438,6 +3394,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
@@ -2500,6 +3462,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
     "node_modules/secure-json-parse": {
@@ -2692,6 +3663,25 @@
         }
       }
     },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
@@ -2704,6 +3694,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -2746,6 +3748,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -2796,9 +3804,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "5.6.0",
@@ -2835,11 +3841,43 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/url-template": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
       "license": "BSD"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.8",
@@ -3041,6 +4079,33 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xmldoc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
+      "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/testes/backend/package.json
+++ b/testes/backend/package.json
@@ -8,6 +8,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1056.0",
+    "@aws-sdk/lib-storage": "^3.1056.0",
+    "@aws-sdk/s3-request-presigner": "^3.1056.0",
     "@hono/zod-openapi": "^1.2.3",
     "@prisma/adapter-pg": "^7.6.0",
     "@prisma/client": "^7.6.0",
@@ -25,6 +28,7 @@
     "i18n-iso-countries": "^7.14.0",
     "iso-3166-2": "^1.0.0",
     "nodemailer": "^8.0.7",
+    "pdfmake": "^0.3.9",
     "pg": "^8.20.0",
     "pg-boss": "^12.18.2",
     "pino": "^10.3.1",
@@ -34,6 +38,7 @@
   "devDependencies": {
     "@types/iso-3166-2": "^1.0.4",
     "@types/node": "^20.11.17",
+    "@types/pdfmake": "^0.3.3",
     "@vitest/coverage-v8": "^4.1.3",
     "pino-pretty": "^13.1.3",
     "typescript": "^5.8.3",


### PR DESCRIPTION
## Why is this PR necessary?
Synchronous PDF generation blocks the Node.js event loop and causes high memory usage on large datasets. This PR shifts report generation to an asynchronous background worker.

## What does it do?
* **Background Processing:** Delegates PDF generation to a background queue using `pg-boss`.
* **Memory Optimization:** Streams the PDF directly to Cloudflare R2 (`uploadStream`) and enforces a strict 2,000 record limit per report.
* **Monitoring:** Implements a Server-Sent Events (SSE) endpoint to push progress, errors, and the final download URL to the client.
* **Modularity:** Separates logic into dedicated data, analytics, and rendering (`pdfmake`) modules.
* **New Endpoints:**
  * `GET /expenses/reports` (Queues the job and returns a `jobId`)
  * `GET /expenses/reports/status/:jobId` (SSE stream for job status)

## Notes
Design plan: `docs/planning/PLAN_async_report_generation.md`