### PR TITLE
feat(auth): add refresh token support

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,7 +3,9 @@ PORT=3001
 SALT_ROUNDS=10
 LOG_LEVEL=debug
 JWT_SECRET= # node -e "const crypto = require('crypto'); console.log(crypto.randomBytes(64).toString('hex'));"
-JWT_EXPIRES_IN=86400 # 86400 segundos = 24 horas
+JWT_EXPIRES_IN=1800 # 1800 segundos = 30m
+JWT_REFRESH_SECRET= # node -e "const crypto = require('crypto'); console.log(crypto.randomBytes(64).toString('hex'));"
+REFRESH_TOKEN_EXPIRES_DAYS=14
 FRONTEND_URL=http://localhost:3000
 ALLOWED_ORIGINS=${FRONTEND_URL},https://frontend.deploy.com
 DATABASE_URL="postgresql://user:password@localhost:5432/flycostsdb"

--- a/backend/README.md
+++ b/backend/README.md
@@ -46,29 +46,13 @@
       ```env
       DATABASE_URL="postgresql://user:password@localhost:5432/flycostsdb"
       ```
+   **JWT_SECRET**: Chave p/ Access Token. Gere com: `node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"`
 
-   **JWT_SECRET**:
-    - Chave mestra utilizada para assinar e validar os tokens de autenticação (JWT).
-    - **Geração:** Gere uma chave segura executando o comando no terminal:
-      ```bash
-      node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
-      ```
-    - Atribua o valor gerado ao seu `.env`:
-      ```env
-      JWT_SECRET="seu_token_gerado_aqui"
-      ```
+   **JWT_REFRESH_SECRET**: Chave p/ Refresh Token. Gere outra chave com o mesmo comando.
 
-   **JWT_EXPIRE_AT**:
-    - Define o tempo de vida útil do token, em segundos, a partir do momento da emissão.
-    - **Formato:** Valor numérico inteiro representando o total de segundos.
-    - **Exemplos comuns:**
-        - `3600` (1 hora)
-        - `86400` (1 dia)
-        - `604800` (1 semana)
-    - Atribua o valor desejado (exemplo de 1 dia):
-      ```env
-      JWT_EXPIRE_AT=86400
-      ```
+   **JWT_EXPIRES_IN**: Duração do Access Token (s). Ex: `1800` (30m).
+
+   **REFRESH_TOKEN_EXPIRES_DAYS**: Duração da sessão deslizante (dias). Ex: `14`.
 
 4. **Iniciando a aplicação:**
     ```bash

--- a/backend/prisma/migrations/20260610193823_add_user_session_tbl/migration.sql
+++ b/backend/prisma/migrations/20260610193823_add_user_session_tbl/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "UserSession" (
+    "id" TEXT NOT NULL,
+    "jti" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserSession_jti_key" ON "UserSession"("jti");
+
+-- CreateIndex
+CREATE INDEX "UserSession_userId_idx" ON "UserSession"("userId");
+
+-- AddForeignKey
+ALTER TABLE "UserSession" ADD CONSTRAINT "UserSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,6 +21,20 @@ model User {
   createdAt       DateTime         @default(now())
   updatedAt       DateTime         @updatedAt
   profile         Profile?
+  sessions        UserSession[]
+}
+
+model UserSession {
+  id        String   @id @default(uuid())
+  jti       String   @unique // JWT ID vinculado ao Refresh Token
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  expiresAt DateTime
+  revokedAt DateTime? 
+  createdAt DateTime  @default(now())
+
+  @@index([userId])
 }
 
 model Profile {

--- a/backend/src/constants/auth.constant.ts
+++ b/backend/src/constants/auth.constant.ts
@@ -1,1 +1,19 @@
+import type { CookieOptions } from 'hono/utils/cookie'
+import env from '@/env'
+
 export const PASSWORD_RESET_TOKEN_EXPIRES_IN_HOURS = 1
+
+export function getRefreshTokenCookieOptions(): CookieOptions {
+  const sameSite = env.COOKIE_SAME_SITE
+
+  // RFC: Se sameSite for None, secure TEM que ser true
+  const isSecure = sameSite === 'None' ? true : env.NODE_ENV === 'production'
+
+  return {
+    path: '/',
+    httpOnly: true,
+    secure: isSecure,
+    sameSite,
+    maxAge: env.REFRESH_TOKEN_EXPIRES_DAYS * 24 * 60 * 60, // Dias em Segundos
+  }
+}

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -11,7 +11,10 @@ const EnvSchema = z.object({
   LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']).default('info'),
   JWT_SECRET: z.string(),
   JWT_EXPIRES_IN: z.coerce.number(),
+  JWT_REFRESH_SECRET: z.string(),
+  REFRESH_TOKEN_EXPIRES_DAYS: z.coerce.number().default(14),
   SALT_ROUNDS: z.coerce.number().default(10),
+  COOKIE_SAME_SITE: z.enum(['Strict', 'Lax', 'None']).default('Lax'),
   ALLOWED_ORIGINS: z.string()
     .transform(str => str.split(','))
     .pipe(z.array(z.url()))

--- a/backend/src/lib/problems.ts
+++ b/backend/src/lib/problems.ts
@@ -13,6 +13,12 @@ export const PROBLEM_DEFINITIONS = {
     type: 'urn:sgda:auth:security:unauthorized',
     detail: 'Access denied. You must be authenticated to continue.',
   },
+  SESSION_EXPIRED: {
+    status: 401,
+    title: 'Session Expired',
+    type: 'urn:sgda:auth:security:session-expired',
+    detail: 'Your access token has expired. Please refresh your session.',
+  },
   INVALID_CREDENTIALS: {
     status: 401,
     title: 'Invalid credentials',

--- a/backend/src/lib/type.ts
+++ b/backend/src/lib/type.ts
@@ -9,6 +9,7 @@ import type { ValidationErrorItem } from '@/schemas/shared.schema'
 export type AppAuthPayload = {
   sub: string
   role: UserRole
+  jti?: string
 }
 
 export type AppContext = {

--- a/backend/src/middlewares/require-auth.ts
+++ b/backend/src/middlewares/require-auth.ts
@@ -2,6 +2,7 @@ import type { AppContext } from '@/lib/type'
 import { createMiddleware } from 'hono/factory'
 import { HTTPException } from 'hono/http-exception'
 import { jwt } from 'hono/jwt'
+import { JwtTokenExpired } from 'hono/utils/jwt/types'
 import * as codes from 'stoker/http-status-codes'
 import env from '@/env'
 import { problems } from '@/lib/problems'
@@ -18,6 +19,10 @@ export default createMiddleware<AppContext>(async (c, next) => {
   catch (error) {
     if (error instanceof HTTPException && error.status === codes.UNAUTHORIZED) {
       c.get('logger').warn(`Authentication Failure [401]: ${error.message}`)
+
+      if (error.cause instanceof JwtTokenExpired) {
+        throw problems.create('SESSION_EXPIRED')
+      }
 
       throw problems.create('UNAUTHORIZED', { detail: 'Access denied. You must be authenticated to continue.' })
     }

--- a/backend/src/routes/auth/auth.handler.ts
+++ b/backend/src/routes/auth/auth.handler.ts
@@ -1,11 +1,13 @@
-import type { ForgotPasswordRoute, LoginRoute, RegisterRoute, ResetPasswordRoute } from './auth.route'
+import type { ForgotPasswordRoute, LoginRoute, LogoutRoute, RefreshRoute, RegisterRoute, ResetPasswordRoute } from './auth.route'
 import type { AppRouteHandler } from '@/lib/type'
+import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 import * as codes from 'stoker/http-status-codes'
+import { getRefreshTokenCookieOptions } from '@/constants/auth.constant'
 import env from '@/env'
 import { emailService } from '@/lib/email/service'
 import prisma from '@/lib/orm'
 import { problems } from '@/lib/problems'
-import { createPasswordResetToken, generateAccessToken, resetPassword as resetPasswordService, verifyCredentials } from '@/services/auth.service'
+import { createPasswordResetToken, createSession, extendSession, generateAccessToken, generateRefreshToken, resetPassword as resetPasswordService, revokeSession, validateSession, verifyCredentials, verifyRefreshToken } from '@/services/auth.service'
 import { findInviteByCode, validateAndConsume } from '@/services/invite.service'
 import { createUser, getUserByEmail } from '@/services/user.service'
 
@@ -55,7 +57,65 @@ export const login: AppRouteHandler<LoginRoute> = async (c) => {
 
   const accessToken = await generateAccessToken(result, env.JWT_SECRET)
 
+  const session = await createSession(result.sub)
+  const refreshToken = await generateRefreshToken(result, session.jti)
+
+  setCookie(c, 'refreshToken', refreshToken, getRefreshTokenCookieOptions())
+
   return c.json({ accessToken }, codes.OK)
+}
+
+export const refresh: AppRouteHandler<RefreshRoute> = async (c) => {
+  const refreshToken = getCookie(c, 'refreshToken')
+
+  if (!refreshToken) {
+    throw problems.create('UNAUTHORIZED')
+  }
+
+  const result = await verifyRefreshToken(refreshToken)
+
+  if ('error' in result) {
+    throw problems.create(result.error)
+  }
+
+  const sessionResult = await validateSession(result.jti)
+
+  if ('error' in sessionResult) {
+    throw problems.create(sessionResult.error)
+  }
+
+  // Sliding Session: Estende a sessão no banco e rotaciona o cookie
+  const extensionResult = await extendSession(result.jti)
+  if ('error' in extensionResult) {
+    throw problems.create(extensionResult.error)
+  }
+
+  const newRefreshToken = await generateRefreshToken({
+    sub: sessionResult.userId,
+    role: sessionResult.user.role,
+  }, result.jti)
+
+  setCookie(c, 'refreshToken', newRefreshToken, getRefreshTokenCookieOptions())
+
+  const accessToken = await generateAccessToken({
+    sub: sessionResult.userId,
+    role: sessionResult.user.role,
+  }, env.JWT_SECRET)
+
+  return c.json({ accessToken }, codes.OK)
+}
+
+export const logout: AppRouteHandler<LogoutRoute> = async (c) => {
+  const refreshToken = deleteCookie(c, 'refreshToken', getRefreshTokenCookieOptions())
+
+  if (refreshToken) {
+    const result = await verifyRefreshToken(refreshToken)
+    if (!('error' in result)) {
+      await revokeSession(result.jti)
+    }
+  }
+
+  return c.json({ message: 'Logged out successfully.' }, codes.OK)
 }
 
 export const forgotPassword: AppRouteHandler<ForgotPasswordRoute> = async (c) => {

--- a/backend/src/routes/auth/auth.route.ts
+++ b/backend/src/routes/auth/auth.route.ts
@@ -1,4 +1,4 @@
-import { createRoute } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import * as codes from 'stoker/http-status-codes'
 import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers'
 import { createMessageObjectSchema } from 'stoker/openapi/schemas'
@@ -11,6 +11,8 @@ export type RegisterRoute = typeof register
 export type LoginRoute = typeof login
 export type ForgotPasswordRoute = typeof forgotPassword
 export type ResetPasswordRoute = typeof resetPassword
+export type RefreshRoute = typeof refresh
+export type LogoutRoute = typeof logout
 
 export const register = createRoute({
   path: '/register',
@@ -36,11 +38,55 @@ export const login = createRoute({
   tags,
   request: { body: jsonContentRequired(LoginSchema, 'User credentials') },
   responses: {
+    [codes.OK]: {
+      content: { 'application/json': { schema: LoginSuccessSchema } },
+      description: 'Authentication successful. The access token is returned in the response body, and a refresh token is set in an httpOnly cookie.',
+      headers: z.object({
+        'Set-Cookie': z.string().openapi({
+          description: 'The refresh token in an httpOnly cookie.',
+          example: 'refreshToken=...; HttpOnly; SameSite=Lax',
+        }),
+      }),
+    },
+    ...registryResponses('UNAUTHORIZED', 'VALIDATION_ERROR'),
+  },
+})
+
+export const refresh = createRoute({
+  path: '/refresh',
+  method: 'post',
+  summary: 'Refresh access token',
+  description: 'Issues a new access token using a valid refresh token from cookies.',
+  tags,
+  request: {},
+  responses: {
     [codes.OK]: jsonContent(
       LoginSuccessSchema,
-      'Authentication successful. The access token is returned in the response body.',
+      'New access token issued.',
     ),
-    ...registryResponses('UNAUTHORIZED', 'VALIDATION_ERROR'),
+    ...registryResponses('UNAUTHORIZED'),
+  },
+})
+
+export const logout = createRoute({
+  path: '/logout',
+  method: 'post',
+  summary: 'Logout user',
+  description: 'Invalidates the current session and clears the refresh token cookie.',
+  tags,
+  request: {},
+  responses: {
+    [codes.OK]: {
+      description: 'User logged out successfully.',
+      headers: z.object({
+        'Set-Cookie': z.string().openapi({
+          description: 'Clears the refresh token cookie.',
+          example: 'refreshToken=; Max-Age=0; Path=/; HttpOnly',
+        }),
+      }),
+      content: { 'application/json': { schema: createMessageObjectSchema('Logged out successfully.') } },
+    },
+    ...registryResponses('UNAUTHORIZED'),
   },
 })
 

--- a/backend/src/routes/auth/index.ts
+++ b/backend/src/routes/auth/index.ts
@@ -5,6 +5,8 @@ import * as routes from './auth.route'
 const router = createRouter().basePath('/auth')
   .openapi(routes.register, handlers.register)
   .openapi(routes.login, handlers.login)
+  .openapi(routes.refresh, handlers.refresh)
+  .openapi(routes.logout, handlers.logout)
   .openapi(routes.forgotPassword, handlers.forgotPassword)
   .openapi(routes.resetPassword, handlers.resetPassword)
 

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,13 +1,15 @@
-import type { z } from '@hono/zod-openapi'
+import type { Prisma, UserSession } from '@/generated/prisma/client'
 import type { ServiceResult } from '@/lib/problems'
 import type { AppAuthPayload } from '@/lib/type'
 import type { LoginSchema } from '@/schemas/auth.schema'
-import crypto from 'node:crypto'
+import crypto, { randomUUID } from 'node:crypto'
+import { z } from '@hono/zod-openapi'
 import bcrypt, { compare } from 'bcryptjs'
-import { sign } from 'hono/jwt'
+import { sign, verify } from 'hono/jwt'
 import { PASSWORD_RESET_TOKEN_EXPIRES_IN_HOURS } from '@/constants/auth.constant'
 import { mockInviteCode } from '@/constants/invite.constant'
 import env from '@/env'
+import { UserRole } from '@/generated/prisma/client'
 import { dayjs } from '@/lib/date'
 import prisma from '@/lib/orm'
 import { getUserByEmail } from './user.service'
@@ -44,6 +46,95 @@ export async function generateAccessToken(payload: AppAuthPayload, secret: strin
   )
 
   return token
+}
+
+export const sessionInclude = { user: true } satisfies Prisma.UserSessionInclude
+
+export type SessionWithUser = Prisma.UserSessionGetPayload<{
+  include: typeof sessionInclude
+}>
+
+export async function createSession(userId: string): Promise<UserSession> {
+  const jti = randomUUID()
+  const expiresAt = dayjs().add(env.REFRESH_TOKEN_EXPIRES_DAYS, 'day')
+    .toDate()
+
+  return prisma.userSession.create({
+    data: {
+      jti,
+      userId,
+      expiresAt,
+    },
+  })
+}
+
+export async function generateRefreshToken(payload: AppAuthPayload, jti: string): Promise<string> {
+  const token = await sign(
+    {
+      ...payload,
+      jti,
+      exp: dayjs().add(env.REFRESH_TOKEN_EXPIRES_DAYS, 'day')
+        .unix(),
+    },
+    env.JWT_REFRESH_SECRET,
+  )
+
+  return token
+}
+
+export async function verifyRefreshToken(token: string): Promise<ServiceResult<AppAuthPayload & { jti: string }, 'UNAUTHORIZED'>> {
+  try {
+    const rawPayload = await verify(token, env.JWT_REFRESH_SECRET, 'HS256')
+    const payload = z.object({
+      sub: z.string(),
+      role: z.enum(UserRole),
+      jti: z.string(),
+    }).parse(rawPayload)
+
+    return payload as AppAuthPayload & { jti: string }
+  }
+  catch {
+    return { error: 'UNAUTHORIZED' }
+  }
+}
+
+export async function validateSession(jti: string): Promise<ServiceResult<SessionWithUser, 'UNAUTHORIZED'>> {
+  const session = await prisma.userSession.findUnique({
+    where: { jti },
+    include: sessionInclude,
+  })
+
+  if (!session || session.revokedAt || dayjs().isAfter(session.expiresAt) || !session.user.isActive) {
+    return { error: 'UNAUTHORIZED' }
+  }
+
+  return session
+}
+export async function extendSession(jti: string): Promise<ServiceResult<UserSession, 'UNAUTHORIZED'>> {
+  try {
+    const expiresAt = dayjs().add(env.REFRESH_TOKEN_EXPIRES_DAYS, 'day')
+      .toDate()
+
+    return await prisma.userSession.update({
+      where: { jti },
+      data: { expiresAt },
+    })
+  }
+  catch {
+    return { error: 'UNAUTHORIZED' }
+  }
+}
+export async function revokeSession(jti: string): Promise<ServiceResult<{ success: true }, 'UNAUTHORIZED'>> {
+  const result = await prisma.userSession.updateMany({
+    where: { jti },
+    data: { revokedAt: new Date() },
+  })
+
+  if (result.count === 0) {
+    return { error: 'UNAUTHORIZED' }
+  }
+
+  return { success: true }
 }
 
 export async function createPasswordResetToken(email: string): Promise<ServiceResult<{ token: string }, 'USER_NOT_FOUND'>> {

--- a/backend/tests/integration/auth/refresh-token.spec.ts
+++ b/backend/tests/integration/auth/refresh-token.spec.ts
@@ -1,0 +1,159 @@
+import { testClient } from 'hono/testing'
+import { parse } from 'hono/utils/cookie'
+import * as status from 'stoker/http-status-codes'
+import { afterAll, afterEach, assert, beforeAll, describe, expect, it, vi } from 'vitest'
+import { createTestApp } from '@/lib/config'
+import prisma from '@/lib/orm'
+import { auth, me } from '@/routes'
+import { seedUsers } from '@/seeds'
+import { expectProblem } from '../../util/assertions'
+
+// Mocking env to have a very short JWT expiration for testing SESSION_EXPIRED
+vi.mock('@/env', async () => {
+  const actual = await vi.importActual<typeof import('@/env')>('@/env')
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      JWT_EXPIRES_IN: 1, // 1 second
+    },
+  }
+})
+
+const client = testClient(createTestApp(auth).route('/', me))
+
+describe('[Auth] Refresh Token Flow', () => {
+  beforeAll(async () => {
+    await seedUsers()
+  })
+
+  afterEach(async () => {
+    await prisma.userSession.deleteMany()
+    vi.useRealTimers()
+  })
+
+  afterAll(async () => {
+    await prisma.userSession.deleteMany()
+    await prisma.user.deleteMany()
+    vi.restoreAllMocks()
+  })
+
+  it('deve realizar login e retornar accessToken no json e refreshToken no cookie', async () => {
+    const res = await client.auth.login.$post({
+      json: {
+        email: 'aluno@test.com',
+        password: 'Test@1234',
+      },
+    })
+
+    assert(res.status === status.OK)
+
+    const json = await res.json()
+    expect(json.accessToken).toBeDefined()
+
+    // Verificando Cookie
+    const setCookie = res.headers.get('set-cookie')
+    expect(setCookie).toContain('refreshToken=')
+    expect(setCookie).toContain('HttpOnly')
+    expect(setCookie).toContain('SameSite=Lax')
+
+    // Verificando persistência no banco
+    const user = await prisma.user.findUnique({ where: { email: 'aluno@test.com' } })
+    const session = await prisma.userSession.findFirst({ where: { userId: user!.id } })
+
+    expect(session).not.toBeNull()
+    expect(session?.revokedAt).toBeNull()
+  })
+
+  it('deve renovar o accessToken usando um refreshToken válido e estender a sessão (Sliding Session)', async () => {
+    // 1. Faz login para pegar o cookie
+    const loginRes = await client.auth.login.$post({
+      json: {
+        email: 'aluno@test.com',
+        password: 'Test@1234',
+      },
+    })
+
+    const setCookie = loginRes.headers.get('set-cookie')
+    const cookies = parse(setCookie!)
+    const refreshToken = cookies.refreshToken
+
+    // Pega a data de expiração ANTES do refresh
+    const sessionBefore = await prisma.userSession.findFirst({ where: { user: { email: 'aluno@test.com' } } })
+    const expiresAtBefore = sessionBefore!.expiresAt.getTime()
+
+    // Avança o tempo do sistema em 1 dia para forçar uma diferença clara na renovação
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(Date.now() + 24 * 60 * 60 * 1000))
+
+    // 2. Tenta dar refresh
+    const res = await client.auth.refresh.$post({}, { headers: { Cookie: `refreshToken=${refreshToken}` } })
+
+    assert(res.status === status.OK)
+    const json = await res.json()
+    expect(json.accessToken).toBeDefined()
+
+    // Pega a data de expiração DEPOIS do refresh
+    const sessionAfter = await prisma.userSession.findFirst({ where: { user: { email: 'aluno@test.com' } } })
+    const expiresAtAfter = sessionAfter!.expiresAt.getTime()
+
+    // 3. Asserção da Sliding Session: a nova data de expiração deve ser maior
+    expect(expiresAtAfter).toBeGreaterThan(expiresAtBefore)
+
+    // Restaura o tempo
+    vi.useRealTimers()
+  })
+
+  it('deve realizar logout e invalidar o refreshToken', async () => {
+    // 1. Login
+    const loginRes = await client.auth.login.$post({
+      json: {
+        email: 'aluno@test.com',
+        password: 'Test@1234',
+      },
+    })
+
+    const setCookie = loginRes.headers.get('set-cookie')
+    const cookies = parse(setCookie!)
+    const refreshToken = cookies.refreshToken
+
+    // 2. Logout
+    const logoutRes = await client.auth.logout.$post({}, { headers: { Cookie: `refreshToken=${refreshToken}` } })
+
+    expect(logoutRes.status).toBe(status.OK)
+
+    // Verificando se cookie de limpeza foi enviado
+    const logoutCookie = logoutRes.headers.get('set-cookie')
+    expect(logoutCookie).toContain('Max-Age=0')
+
+    // 3. Tenta dar refresh (Deve falhar agora)
+    const refreshRes = await client.auth.refresh.$post({}, { headers: { Cookie: `refreshToken=${refreshToken}` } })
+
+    await expectProblem(refreshRes, 'UNAUTHORIZED')
+
+    // Verificando no banco
+    const revokedSession = await prisma.userSession.findFirst({ where: { revokedAt: { not: null } } })
+    expect(revokedSession).not.toBeNull()
+  })
+
+  it('deve retornar SESSION_EXPIRED quando o access token expira', async () => {
+    // 1. Login para obter o access token
+    const loginRes = await client.auth.login.$post({
+      json: {
+        email: 'aluno@test.com',
+        password: 'Test@1234',
+      },
+    })
+
+    assert(loginRes.status === status.OK)
+    const { accessToken } = await loginRes.json()
+
+    // 2. Esperar o token expirar (1 segundo + margem)
+    await new Promise(resolve => setTimeout(resolve, 1500))
+
+    // 3. Tentar acessar uma rota protegida (/me)
+    const res = await client.me.$get({}, { headers: { Authorization: `Bearer ${accessToken}` } })
+
+    await expectProblem(res, 'SESSION_EXPIRED')
+  })
+})

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
       NODE_ENV: 'test',
       JWT_SECRET: 'fake-secret',
       JWT_EXPIRES_IN: '3600',
+      JWT_REFRESH_SECRET: 'fake-refresh-secret',
+      REFRESH_TOKEN_EXPIRES_DAYS: '7',
       SALT_ROUNDS: '2',
       LOG_LEVEL: 'debug',
     },


### PR DESCRIPTION
## Why is this PR necessary? What does it do?

Implementação de Refresh Tokens e gestão de sessões. 

Principais mudanças: 
- Gestão de Sessão: Nova tabela UserSession para controle de jti (JWT ID), permitindo revogação e controle de expiração. 
- Atualização dos valores padrões em `.env.example`, access Token agora tem validade curta (30m) e a sessão (Refresh Token) tem validade padrão de 14 dias. (SUGESTÃO)
- Rotação de Tokens: Endpoint /auth/refresh implementa rotação de Refresh Tokens para maior segurança. 
- Adição de novo *problem* no Registry: SESSION_EXPIRED, útil para identificar o momento de realizar novas renovações de sessão.
-  Utilização de melhores práticas de configurações de Cookies.


## Notes 

- Seguimos com a filosofia *Postgres for everything* , visando reduzir complexidade de infraestrutura.
  - Possíveis melhorias:  Extensão por limpeza de dados.
- Variáveis de Ambiente: Adicionadas JWT_REFRESH_SECRET, REFRESH_TOKEN_EXPIRES_DAYS e COOKIE_SAME_SITE ao .env.example.
  - COOKIE_SAME_SITE foi introduzida para dar flexibilidade à infraestrutura, permitindo ajustar o comportamento da sessão para cenários de mesma origem (Lax) ou onde o Frontend e Backend estão em domínios diferentes (SameSite=None).