### PR TITLE
feat(notifications): enable staff triggers for expense request analysis

### DIFF
--- a/backend/src/constants/expense.constant.ts
+++ b/backend/src/constants/expense.constant.ts
@@ -38,3 +38,26 @@ export const EXPENSE_VISIBILITY_BY_ROLE: Record<UserRole, ExpenseRequestStatus[]
     ExpenseRequestStatus.CONCLUIDO,
   ],
 }
+
+/**
+ * Mapeia se o aluno deve ser enviado para a página de Detalhes ou Edição.
+ * Por padrão é 'detail', mas EM_EDICAO exige 'edit'.
+ */
+export const FRONTEND_PATH_BY_STATUS: Partial<Record<ExpenseRequestStatus, 'detail' | 'edit'>> = { [ExpenseRequestStatus.EM_EDICAO]: 'edit' }
+
+/**
+ * Restrições extras de cargo para transições específicas.
+ * Ex: Apenas ADMIN pode colocar uma despesa em EM_EDICAO.
+ */
+export const REQUIRED_ROLE_FOR_STATUS: Partial<Record<ExpenseRequestStatus, UserRole[]>> = { [ExpenseRequestStatus.EM_EDICAO]: [UserRole.ADMIN] }
+
+/**
+ * Mapeia quais cargos do staff devem ser notificados baseado no novo status da despesa.
+ *
+ * PENDENTE -> Coordenadores (para avaliação)
+ * APROVADO -> Admins (para processamento financeiro)
+ */
+export const STAFF_NOTIFICATION_TARGETS_BY_STATUS: Partial<Record<ExpenseRequestStatus, UserRole[]>> = {
+  [ExpenseRequestStatus.PENDENTE]: [UserRole.COORDENADOR],
+  [ExpenseRequestStatus.APROVADO]: [UserRole.ADMIN],
+}

--- a/backend/src/constants/user.constant.ts
+++ b/backend/src/constants/user.constant.ts
@@ -3,3 +3,9 @@ import { UserRole } from '@/generated/prisma/enums'
 export const ROLES_ALLOWED_TO_HAVE_PROFILE: UserRole[] = [
   UserRole.ALUNO,
 ] as const
+
+export const ROLE_FRONTEND_SLUG: Record<UserRole, string> = {
+  [UserRole.ALUNO]: 'student',
+  [UserRole.COORDENADOR]: 'coordinator',
+  [UserRole.ADMIN]: 'admin',
+}

--- a/backend/src/jobs/send-email.job.ts
+++ b/backend/src/jobs/send-email.job.ts
@@ -2,7 +2,7 @@ import type { Job } from 'pg-boss'
 import type { SendEmailInput } from '@/lib/email/type'
 import { EMAIL_ERROR_CODES } from '@/constants/email.constant'
 import { createEmailProvider } from '@/lib/email/providers'
-import { PasswordRecoveryEmail, StatusChangeEmail } from '@/lib/email/templates'
+import { PasswordRecoveryEmail, StaffNotificationEmail, StatusChangeEmail } from '@/lib/email/templates'
 import { renderEmailHtml } from '@/lib/email/util'
 import { BaseJob } from '@/lib/jobs'
 import { logger } from '@/lib/logger'
@@ -43,6 +43,19 @@ export class SendEmailJob extends BaseJob<EmailJobData, void> {
         }
         case 'password-recovery': {
           const component = await PasswordRecoveryEmail(template.props)
+          if (!component) {
+            return {
+              success: false,
+              error: EMAIL_ERROR_CODES.FAILED_TO_RENDER_TEMPLATE,
+            }
+          }
+          return {
+            success: true,
+            html: renderEmailHtml(component.toString()),
+          }
+        }
+        case 'staff-notification': {
+          const component = await StaffNotificationEmail(template.props)
           if (!component) {
             return {
               success: false,

--- a/backend/src/lib/email/templates/index.ts
+++ b/backend/src/lib/email/templates/index.ts
@@ -1,4 +1,5 @@
 export * from './base.layout'
 export * from './components'
 export * from './password-recovery'
+export * from './staff-notification'
 export * from './status-change'

--- a/backend/src/lib/email/templates/staff-notification.tsx
+++ b/backend/src/lib/email/templates/staff-notification.tsx
@@ -1,0 +1,167 @@
+import type { FC } from 'hono/jsx'
+import type { ExpenseRequestStatus } from '@/generated/prisma/client'
+import { ExpenseRequestStatus as Status } from '@/generated/prisma/client'
+import { BaseEmail, EMAIL_THEME } from './base.layout'
+
+export type StaffNotificationEmailProps = {
+  staffName: string
+  eventDetails: string[]
+  expenseTitle: string
+  status: ExpenseRequestStatus
+  date: string
+  actionUrl: string
+  projectName?: string | null
+  categories?: string[]
+  articleClassification?: string
+}
+
+const CONFIG = {
+  [Status.PENDENTE]: {
+    subjectPrefix: 'Solicitação Pendente',
+    message: 'Uma nova solicitação foi submetida e foi adicionada à fila da coordenação. Requer sua avaliação para prosseguir.',
+    actionLabel: 'Analisar Solicitação',
+    color: '#6b7280',
+    bgColor: '#f3f4f6',
+  },
+  [Status.APROVADO]: {
+    subjectPrefix: 'Aprovado pela Coordenação',
+    message: 'A solicitação foi aprovada pela coordenação. Faça a revisão dos dados e vincule o projeto para iniciar a cotação.',
+    actionLabel: 'Iniciar Processamento',
+    color: '#059669',
+    bgColor: '#ecfdf5',
+  },
+}
+
+export const StaffNotificationEmail: FC<StaffNotificationEmailProps> = ({
+  staffName,
+  eventDetails,
+  expenseTitle,
+  status,
+  date,
+  actionUrl,
+  projectName,
+  categories,
+  articleClassification,
+}) => {
+  const config = CONFIG[status as keyof typeof CONFIG] || CONFIG[Status.PENDENTE]
+
+  return (
+    <BaseEmail title={config.subjectPrefix}>
+      <p style="margin-top: 0;">
+        Olá,
+        {' '}
+        <strong>{staffName}</strong>
+        .
+      </p>
+      <p style="color: #4b5563; font-size: 16px;">
+        Há uma nova tarefa na sua fila de trabalho referente ao sistema de ajuda de custo:
+      </p>
+
+      {/* Main Context Banner */}
+      <div style={`margin: 32px 0; padding: 24px; background-color: ${config.bgColor}; border-radius: 12px; text-align: center; border: 1px solid ${config.color}20;`}>
+        <p style={`margin: 0; font-size: 16px; color: ${EMAIL_THEME.colors.text}; line-height: 1.5; font-weight: 500;`}>
+          {config.message}
+        </p>
+      </div>
+
+      {/* Summary Card */}
+      <div style={`margin-bottom: 32px; border: 1px solid ${EMAIL_THEME.colors.border}; border-radius: 12px; overflow: hidden;`}>
+        {/* Header do Card */}
+        <div style={`padding: 16px 20px; background-color: ${EMAIL_THEME.colors.footer}; border-bottom: 1px solid ${EMAIL_THEME.colors.border};`}>
+          <p style="margin: 0 0 4px 0; font-size: 11px; color: #6b7280; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;">
+            Resumo da Solicitação
+          </p>
+          <h2 style="margin: 0; font-size: 15px; color: #111827; font-weight: 700; line-height: 1.4;">
+            {expenseTitle}
+          </h2>
+        </div>
+
+        <div style="padding: 24px;">
+          <table width="100%" cellPadding={0} cellSpacing={0} role="presentation">
+            {/* Seção do Evento */}
+            {eventDetails && eventDetails.length > 0 && (
+              <tr>
+                <td style="padding-bottom: 16px; color: #6b7280; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.025em; vertical-align: top; width: 38%;">
+                  Dados do Evento:
+                </td>
+                <td style="padding-bottom: 16px; vertical-align: top;">
+                  <ul style="margin: 0; padding-left: 14px; color: #111827; font-size: 14px;">
+                    {(eventDetails || []).map((detail, index) => (
+                      <li key={index} style="margin-bottom: 4px; font-weight: 600;">{detail}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            )}
+
+            {/* Preferências (Categorias) */}
+            {categories && categories.length > 0 && (
+              <tr>
+                <td style="padding-bottom: 16px; color: #6b7280; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.025em; vertical-align: top;">
+                  Preferências:
+                </td>
+                <td style="padding-bottom: 16px; vertical-align: top;">
+                  <ul style="margin: 0; padding-left: 14px; color: #111827; font-size: 14px;">
+                    {categories.map(category => (
+                      <li key={category} style="margin-bottom: 4px;">{category}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            )}
+
+            {/* Qualis (Substituindo Memorando) */}
+            <tr>
+              <td style="padding-bottom: 16px; color: #6b7280; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.025em; vertical-align: middle;">
+                Classificação QUALIS:
+              </td>
+              <td style="padding-bottom: 16px; vertical-align: middle;">
+                <span style="display: inline-block; background-color: #eff6ff; color: #1d4ed8; padding: 4px 10px; border-radius: 6px; font-size: 12px; font-weight: 700; border: 1px solid #dbeafe;">
+                  {articleClassification}
+                </span>
+              </td>
+            </tr>
+
+            {/* Projeto (se houver) */}
+            {projectName && (
+              <tr>
+                <td style="padding-bottom: 16px; color: #6b7280; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.025em; vertical-align: top;">
+                  Projeto:
+                </td>
+                <td style="padding-bottom: 16px; color: #111827; font-size: 14px; font-weight: 500;">
+                  {projectName}
+                </td>
+              </tr>
+            )}
+
+            {/* Data */}
+            <tr>
+              <td style="padding-top: 8px; border-top: 1px solid #f3f4f6; color: #9ca3af; font-size: 11px; font-weight: 600; text-transform: uppercase; vertical-align: top;">
+                Submetido em:
+              </td>
+              <td style="padding-top: 8px; border-top: 1px solid #f3f4f6; color: #9ca3af; font-size: 11px; vertical-align: top;">
+                {date}
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+
+      {/* Action Button */}
+      <div style="text-align: center; margin: 40px 0;">
+        <a
+          href={actionUrl}
+          style={`display: inline-block; padding: 16px 36px; background-color: ${EMAIL_THEME.colors.accent}; color: #ffffff; text-decoration: none; border-radius: 10px; font-weight: 700; font-size: 16px; box-shadow: 0 4px 10px -2px rgba(0, 0, 0, 0.1);`}
+        >
+          {config.actionLabel}
+        </a>
+      </div>
+
+      <div style="margin-top: 48px; padding-top: 24px; border-top: 1px solid #f3f4f6; text-align: center;">
+        <p style="margin: 0; font-size: 13px; color: #9ca3af;">
+          Esta é uma notificação automática do sistema SGDA.
+        </p>
+      </div>
+    </BaseEmail>
+  )
+}

--- a/backend/src/lib/email/type.ts
+++ b/backend/src/lib/email/type.ts
@@ -22,7 +22,22 @@ export type PasswordRecoveryTemplateData = {
   }
 }
 
-export type TemplateData = StatusChangeTemplateData | PasswordRecoveryTemplateData
+export type StaffNotificationTemplateData = {
+  type: 'staff-notification'
+  props: {
+    staffName: string
+    eventDetails: string[]
+    expenseTitle: string
+    status: ExpenseRequestStatus
+    date: string
+    actionUrl: string
+    projectName?: string | null
+    categories?: string[]
+    articleClassification?: string
+  }
+}
+
+export type TemplateData = StatusChangeTemplateData | PasswordRecoveryTemplateData | StaffNotificationTemplateData
 
 export type SendEmailInput = {
   to: string

--- a/backend/src/services/expense.service.ts
+++ b/backend/src/services/expense.service.ts
@@ -2,7 +2,7 @@ import type { z } from '@hono/zod-openapi'
 import type { Prisma } from '@/generated/prisma/client'
 import type { ServiceResult } from '@/lib/problems'
 import type { CreateExpenseSchema, ExpenseListQuerySchema, UpdateExpenseSchema } from '@/schemas/expense.schema'
-import { EXPENSE_STATUS_TRANSITIONS, EXPENSE_VISIBILITY_BY_ROLE, STATUSES_WHERE_REASON_REQUIRED } from '@/constants/expense.constant'
+import { EXPENSE_STATUS_TRANSITIONS, EXPENSE_VISIBILITY_BY_ROLE, REQUIRED_ROLE_FOR_STATUS, STAFF_NOTIFICATION_TARGETS_BY_STATUS, STATUSES_WHERE_REASON_REQUIRED } from '@/constants/expense.constant'
 import { MEMORANDUM_DOWNLOAD_URL_EXPIRY_SECONDS } from '@/constants/file.constant'
 import { ExpenseRequestStatus } from '@/generated/prisma/client'
 import { UserRole } from '@/generated/prisma/enums'
@@ -10,6 +10,7 @@ import prisma from '@/lib/orm'
 import { deleteFile, getSignedDownloadUrl, isStorageConfigured, uploadFile, validatePDF } from '@/lib/storage'
 import { getProjectBudgetMetrics } from './budget.service'
 import { notifyStatusChange } from './notifications'
+import { notifyStaffOnStatusChange } from './notifications/staff.notification'
 
 import { createSurveyAnswer, validateAnswers } from './preference-survey.service'
 
@@ -50,7 +51,12 @@ export const expenseInclude = {
       id: true,
       data: true,
       surveyId: true,
-      survey: { select: { schema: true } },
+      survey: {
+        select: {
+          schema: true,
+          expenseCategory: { select: { name: true } },
+        },
+      },
     },
   },
 } satisfies Prisma.ExpenseRequestInclude
@@ -87,10 +93,24 @@ export async function createExpenseRequest(userId: string, data: CreateExpenseDT
       )
     }
 
-    return tx.expenseRequest.findUnique({
+    const result = await tx.expenseRequest.findUnique({
       where: { id: expense.id },
       include: expenseInclude,
     })
+
+    if (result) {
+      const staffTargets = STAFF_NOTIFICATION_TARGETS_BY_STATUS[ExpenseRequestStatus.PENDENTE]
+      if (staffTargets) {
+        await notifyStaffOnStatusChange(
+          result,
+          ExpenseRequestStatus.PENDENTE,
+          staffTargets,
+          tx,
+        )
+      }
+    }
+
+    return result
   })
 
   if (!result) {
@@ -155,7 +175,8 @@ export async function updateExpenseStatus(
     return { error: 'EXPENSE_NOT_FOUND' }
   }
 
-  if (newStatus === ExpenseRequestStatus.EM_EDICAO && userRole !== UserRole.ADMIN) {
+  const requiredRoles = REQUIRED_ROLE_FOR_STATUS[newStatus]
+  if (requiredRoles && !requiredRoles.includes(userRole)) {
     return { error: 'FORBIDDEN' }
   }
 
@@ -191,19 +212,33 @@ export async function updateExpenseStatus(
       break
   }
 
-  const updatedRequest = await prisma.expenseRequest.update({
-    where: { id },
-    data: updateData,
-    include: expenseInclude,
+  return prisma.$transaction(async (tx) => {
+    const updatedRequest = await tx.expenseRequest.update({
+      where: { id },
+      data: updateData,
+      include: expenseInclude,
+    })
+
+    await notifyStatusChange(
+      updatedRequest.studentId,
+      updatedRequest,
+      updatedRequest.status,
+      null,
+      tx,
+    )
+
+    const staffTargets = STAFF_NOTIFICATION_TARGETS_BY_STATUS[newStatus]
+    if (staffTargets) {
+      await notifyStaffOnStatusChange(
+        updatedRequest,
+        newStatus,
+        staffTargets,
+        tx,
+      )
+    }
+
+    return updatedRequest
   })
-
-  await notifyStatusChange(
-    updatedRequest.studentId,
-    updatedRequest,
-    updatedRequest.status,
-  )
-
-  return updatedRequest
 }
 
 export async function assignProjectToExpense(expenseId: string, projectId: string): Promise<ServiceResult<ExpenseWithRelations, 'EXPENSE_NOT_FOUND' | 'INVALID_EXPENSE_STATE' | 'PROJECT_NOT_FOUND' | 'PROJECT_ARCHIVED' | 'PROJECT_INSUFFICIENT_FUNDS'>> {
@@ -397,11 +432,23 @@ export async function updateExpense(
     if (article)
       updateData.article = article as Prisma.InputJsonValue
 
-    return tx.expenseRequest.update({
+    const result = await tx.expenseRequest.update({
       where: { id },
       data: updateData,
       include: expenseInclude,
     })
+
+    const staffTargets = STAFF_NOTIFICATION_TARGETS_BY_STATUS[ExpenseRequestStatus.APROVADO]
+    if (staffTargets) {
+      await notifyStaffOnStatusChange(
+        result,
+        ExpenseRequestStatus.APROVADO,
+        staffTargets,
+        tx,
+      )
+    }
+
+    return result
   })
 
   return result

--- a/backend/src/services/notifications/email.notification.ts
+++ b/backend/src/services/notifications/email.notification.ts
@@ -1,6 +1,9 @@
 import type { ExpenseRequest, Prisma, Project } from '@/generated/prisma/client'
+import { FRONTEND_PATH_BY_STATUS } from '@/constants/expense.constant'
+import { ROLE_FRONTEND_SLUG } from '@/constants/user.constant'
 import env from '@/env'
 import { ExpenseRequestStatus } from '@/generated/prisma/client'
+import { UserRole } from '@/generated/prisma/enums'
 import { dayjs } from '@/lib/date'
 import { emailService } from '@/lib/email/service'
 import { logger } from '@/lib/logger'
@@ -17,11 +20,9 @@ function getStatusChangeReason(status: ExpenseRequestStatus, expense: Pick<Expen
 }
 
 function getExpenseDetailUrl(expenseId: string, status: ExpenseRequestStatus) {
-  const baseUrl = `${env.FRONTEND_URL}/dashboard/student/expenses`
-  if (status === ExpenseRequestStatus.EM_EDICAO) {
-    return `${baseUrl}/edit/${expenseId}`
-  }
-  return `${baseUrl}/detail/${expenseId}`
+  const slug = ROLE_FRONTEND_SLUG[UserRole.ALUNO]
+  const path = FRONTEND_PATH_BY_STATUS[status] ?? 'detail'
+  return `${env.FRONTEND_URL}/dashboard/${slug}/expenses/${path}/${expenseId}`
 }
 
 export async function sendStatusChangeEmail(

--- a/backend/src/services/notifications/in-app.notification.ts
+++ b/backend/src/services/notifications/in-app.notification.ts
@@ -16,6 +16,18 @@ export async function createInAppNotification(data: {
   })
 }
 
+export async function createManyInAppNotifications(
+  data: { userIds: string[], expenseRequestId: string },
+  tx: Prisma.TransactionClient = prisma,
+) {
+  const notifications = data.userIds.map(userId => ({
+    userId,
+    expenseRequestId: data.expenseRequestId,
+  }))
+
+  return tx.notification.createMany({ data: notifications })
+}
+
 export async function getUserNotifications(
   userId: string,
   filters: z.infer<typeof NotificationQuerySchema> = {},

--- a/backend/src/services/notifications/index.ts
+++ b/backend/src/services/notifications/index.ts
@@ -5,6 +5,7 @@ import { createInAppNotification } from './in-app.notification'
 
 export * from './email.notification'
 export * from './in-app.notification'
+export * from './staff.notification'
 
 export async function notifyStatusChange(
   userId: string,

--- a/backend/src/services/notifications/staff.notification.ts
+++ b/backend/src/services/notifications/staff.notification.ts
@@ -1,0 +1,90 @@
+import type { AnySchema } from 'ajv'
+import type { ExpenseRequest, ExpenseRequestStatus, Prisma, Project } from '@/generated/prisma/client'
+import { ROLE_FRONTEND_SLUG } from '@/constants/user.constant'
+import env from '@/env'
+import { UserRole } from '@/generated/prisma/enums'
+import { eventJSONSchema } from '@/json'
+import { dayjs } from '@/lib/date'
+import { emailService } from '@/lib/email/service'
+import ajv from '@/lib/json-schema-validator'
+import prisma from '@/lib/orm'
+import { getUsersByRoles } from '../user.service'
+import { createManyInAppNotifications } from './in-app.notification'
+
+const validateEvent = ajv.compile(eventJSONSchema as AnySchema)
+
+export async function notifyStaffOnStatusChange(
+  expense: Pick<ExpenseRequest, 'id' | 'title' | 'updatedAt' | 'attachmentKey' | 'event' | 'article'> & {
+    project?: Pick<Project, 'name'> | null
+    surveyAnswers?: Array<{ survey: { expenseCategory: { name: string } } }>
+  },
+  status: ExpenseRequestStatus,
+  targetRoles: UserRole[],
+  tx: Prisma.TransactionClient = prisma,
+) {
+  const staff = await getUsersByRoles(targetRoles, tx)
+
+  if (staff.length === 0)
+    return
+
+  const date = dayjs(expense.updatedAt).format('DD [de] MMMM [de] YYYY')
+
+  // Extrai detalhes do evento usando o Schema JSON via AJV (Cacheado)
+  const isValid = validateEvent(expense.event)
+  const eventDetails = isValid
+    ? Object.values(expense.event as Record<string, any>).filter(v => typeof v === 'string') as string[]
+    : ['Evento não especificado']
+
+  // Extrai a classificação do artigo (QUALIS)
+  const articleData = expense.article as Record<string, any>
+  const articleClassification = articleData?.classification || 'Não informado'
+
+  // Extrai as categorias do formulário (se existirem)
+  const categories = expense.surveyAnswers?.map(ans => ans.survey.expenseCategory.name) || []
+
+  const getActionUrl = (role: UserRole, id: string) => {
+    const slug = ROLE_FRONTEND_SLUG[role]
+    const baseUrl = `${env.FRONTEND_URL}/dashboard/${slug}`
+
+    if (role === UserRole.ADMIN)
+      return `${baseUrl}/expenses/detail?id=${id}`
+
+    if (role === UserRole.COORDENADOR)
+      return baseUrl
+
+    return `${baseUrl}/expenses/detail/${id}`
+  }
+
+  // 1. Notificações In-App em Lote (Performance O(1))
+  await createManyInAppNotifications({
+    userIds: staff.map(u => u.id),
+    expenseRequestId: expense.id,
+  }, tx)
+
+  // 2. Emails em paralelo (Assíncrono via Queue)
+  const emailDispatches = staff.map(async (user) => {
+    await emailService.send({
+      to: user.email,
+      subject: `SGDA: Nova Solicitação para Análise - ${expense.title}`,
+      template: {
+        type: 'staff-notification',
+        props: {
+          staffName: user.name,
+          eventDetails,
+          expenseTitle: expense.title,
+          status,
+          date,
+          actionUrl: getActionUrl(user.role, expense.id),
+          projectName: expense.project?.name,
+          categories: categories.length > 0 ? categories : undefined,
+          articleClassification,
+        },
+      },
+    }, {
+      tx,
+      singletonKey: `staff_notif_${expense.id}_${status}_${user.id}`,
+    })
+  })
+
+  await Promise.all(emailDispatches)
+}

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,5 +1,5 @@
 import type { z } from '@hono/zod-openapi'
-import type { Prisma } from '@/generated/prisma/client'
+import type { Prisma, UserRole } from '@/generated/prisma/client'
 import type { ProfileCreateWithoutUserInput } from '@/generated/prisma/models'
 import type { ServiceResult } from '@/lib/problems'
 import type { RegisterSchema } from '@/schemas/auth.schema'
@@ -68,6 +68,24 @@ export async function getUserById(id: string, tx: Prisma.TransactionClient = pri
   }
 
   return user
+}
+
+export async function getUsersByRoles(
+  roles: UserRole[],
+  tx: Prisma.TransactionClient = prisma,
+) {
+  return tx.user.findMany({
+    where: {
+      role: { in: roles },
+      isActive: true,
+    },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+    },
+  })
 }
 
 export async function updateUser(id: string, data: UpdateUserDTO): Promise<ServiceResult<UserWithProfile, 'USER_NOT_FOUND' | 'FORBIDDEN' | 'CPF_CONFLICT' | 'PROFILE_NOT_ALLOWED'>> {

--- a/backend/tests/integration/notifications/triggers.spec.ts
+++ b/backend/tests/integration/notifications/triggers.spec.ts
@@ -1,9 +1,10 @@
 import type { EmailJobData } from '@/jobs/send-email.job'
+import type { EmitOptions } from '@/lib/jobs'
 import { testClient } from 'hono/testing'
 import * as status from 'stoker/http-status-codes'
 import { afterAll, afterEach, assert, beforeAll, describe, expect, it, vi } from 'vitest'
 import { ID_ALUNO } from '@/constants/seed.constant'
-import { ExpenseRequestStatus } from '@/generated/prisma/enums'
+import { ExpenseRequestStatus, UserRole } from '@/generated/prisma/enums'
 import { jobManager } from '@/jobs'
 import { createTestApp } from '@/lib/config'
 import prisma from '@/lib/orm'
@@ -11,6 +12,7 @@ import { expenses } from '@/routes'
 import { seedExpenseCategories, seedPreferenceSurveys, seedUsers } from '@/seeds'
 import { dummyExpenseCategories } from '@/seeds/expense.category.seed'
 import seedProjects from '@/seeds/project.seed'
+import { notifyStaffOnStatusChange } from '@/services/notifications/staff.notification'
 import { getAuthHeaders } from '../../util'
 
 vi.mock('@/lib/email/providers', () => ({
@@ -87,6 +89,18 @@ describe('[Gatilhos de Notificação] - Gatilhos de mudança de status de despes
     assert(createRes.status === status.CREATED)
     const { id: expenseId } = await createRes.json()
 
+    // 1. Validar que Coordenador foi notificado da nova despesa
+    const staffJob = await spy.waitForJob(
+      data => data.to === 'coordenador@test.com' && data.template?.type === 'staff-notification',
+      'completed',
+    )
+    assert(staffJob)
+    if (staffJob.data.template?.type === 'staff-notification') {
+      expect(staffJob.data.template.props.status).toBe(ExpenseRequestStatus.PENDENTE)
+      expect(staffJob.data.template.props.actionUrl).toContain('/coordinator')
+    }
+    spy.clear()
+
     const rejectionReason = 'Documentação incompleta'
     await expenseClient.expenses[':id'].status.$patch({
       param: { id: expenseId },
@@ -114,7 +128,7 @@ describe('[Gatilhos de Notificação] - Gatilhos de mudança de status de despes
   })
 
   it('deve criar notificações e concluir os jobs de e-mail para aprovação e correção', async () => {
-    const spy = jobManager.boss.getSpy<EmailJobData>('send-email')
+    const emitSpy = vi.spyOn(jobManager, 'emit')
 
     const createRes = await expenseClient.expenses.$post({
       json: {
@@ -135,17 +149,36 @@ describe('[Gatilhos de Notificação] - Gatilhos de mudança de status de despes
     assert(createRes.status === status.CREATED)
 
     const { id: expenseId } = await createRes.json()
+    emitSpy.mockClear()
 
     await expenseClient.expenses[':id'].status.$patch({
       param: { id: expenseId },
       json: { status: ExpenseRequestStatus.APROVADO },
     }, { headers: coordenadorHeaders })
 
-    await spy.waitForJob(
-      data => !!data.template && data.template.type === 'status-change' && data.template.props.newStatus === ExpenseRequestStatus.APROVADO,
-      'completed',
-    )
-    spy.clear()
+    // Wait for async operations to complete
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    // Validar que Admin foi notificado da aprovação
+    const adminCalls = emitSpy.mock.calls.filter((call) => {
+      const data = call[1] as EmailJobData
+      return data.to === 'admin@test.com' && data.template?.type === 'staff-notification' && data.template.props.status === ExpenseRequestStatus.APROVADO
+    })
+    expect(adminCalls).toHaveLength(1)
+    const adminData = adminCalls[0]![1] as EmailJobData
+    assert(adminData.template?.type === 'staff-notification')
+    expect(adminData.template.props.actionUrl).toContain('/admin/expenses/detail?id=')
+    expect(adminData.template.props.categories).toBeDefined()
+    expect(adminData.template.props.categories?.length).toBeGreaterThan(0)
+
+    // Validar o e-mail do aluno
+    const studentCalls = emitSpy.mock.calls.filter((call) => {
+      const data = call[1] as EmailJobData
+      return data.to === 'aluno@test.com' && data.template?.type === 'status-change' && data.template.props.newStatus === ExpenseRequestStatus.APROVADO
+    })
+    expect(studentCalls).toHaveLength(1)
+
+    emitSpy.mockClear()
 
     const correctionReason = 'Por favor, ajuste o título'
     await expenseClient.expenses[':id'].status.$patch({
@@ -156,6 +189,9 @@ describe('[Gatilhos de Notificação] - Gatilhos de mudança de status de despes
       },
     }, { headers: adminHeaders })
 
+    // Wait for async operations to complete
+    await new Promise(resolve => setTimeout(resolve, 50))
+
     const userNotifications = await prisma.notification.findMany({
       where: {
         expenseRequestId: expenseId,
@@ -164,12 +200,132 @@ describe('[Gatilhos de Notificação] - Gatilhos de mudança de status de despes
     })
     expect(userNotifications).toHaveLength(2)
 
-    const correctionJob = await spy.waitForJob(
-      data => data.template?.type === 'status-change' && data.template?.props.newStatus === ExpenseRequestStatus.EM_EDICAO,
-      'completed',
-    )
-    assert(correctionJob)
-    assert(correctionJob.data.template?.type === 'status-change')
-    expect(correctionJob.data.template?.props.reason).toBe(correctionReason)
+    const correctionCalls = emitSpy.mock.calls.filter((call) => {
+      const data = call[1] as EmailJobData
+      return data.to === 'aluno@test.com' && data.template?.type === 'status-change' && data.template.props.newStatus === ExpenseRequestStatus.EM_EDICAO
+    })
+    expect(correctionCalls).toHaveLength(1)
+    const correctionData = correctionCalls[0]![1] as EmailJobData
+    assert(correctionData.template?.type === 'status-change')
+    expect(correctionData.template.props.reason).toBe(correctionReason)
+
+    emitSpy.mockRestore()
+  })
+
+  it('deve notificar apenas staff ativo (Passo 5.1.2)', async () => {
+    // Desativar coordenador temporariamente
+    await prisma.user.update({
+      where: { email: 'coordenador@test.com' },
+      data: { isActive: false },
+    })
+
+    const emitSpy = vi.spyOn(jobManager, 'emit')
+
+    const createRes = await expenseClient.expenses.$post({
+      json: {
+        title: 'Despesa Staff Inativo',
+        event: {
+          name: 'Evento Teste',
+          location: 'Local Teste',
+        },
+        article: { classification: 'Sem Qualis' },
+        surveyAnswers: [{
+          expenseCategoryId: categoryId,
+          data: { invoiceKey: 'formulario-preferencias/test.pdf' },
+        }],
+      },
+    }, { headers: alunoHeaders })
+
+    if (createRes.status !== status.CREATED) {
+      console.error('FAILED CREATE EXPENSE (Staff Inativo):', await createRes.json())
+    }
+    assert(createRes.status === status.CREATED)
+
+    // Verify emit was not called for coordenador
+    const coordinatorCalls = emitSpy.mock.calls.filter((call) => {
+      const data = call[1] as EmailJobData
+      return data.to === 'coordenador@test.com'
+    })
+    expect(coordinatorCalls).toHaveLength(0)
+
+    emitSpy.mockRestore()
+
+    // Reativar para não quebrar outros testes
+    await prisma.user.update({
+      where: { email: 'coordenador@test.com' },
+      data: { isActive: true },
+    })
+  })
+
+  it('deve realizar rollback de notificações se a transação falhar (Passo 5.4.1)', async () => {
+    const expense = await prisma.expenseRequest.create({
+      data: {
+        title: 'Rollback Test',
+        studentId: ID_ALUNO,
+        status: ExpenseRequestStatus.PENDENTE,
+        event: {
+          name: 'Evento Teste',
+          location: 'Local Teste',
+        },
+        article: { classification: 'Sem Qualis' },
+      },
+    })
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        await notifyStaffOnStatusChange(expense, ExpenseRequestStatus.PENDENTE, [UserRole.COORDENADOR], tx)
+        throw new Error('Forced Rollback')
+      })
+    }
+    catch { /* ignore */ }
+
+    const notifications = await prisma.notification.findMany({ where: { expenseRequestId: expense.id } })
+    expect(notifications).toHaveLength(0)
+  })
+
+  it('deve respeitar idempotência via singletonKey (Passo 5.4.2)', async () => {
+    const emitSpy = vi.spyOn(jobManager, 'emit')
+    const expense = await prisma.expenseRequest.create({
+      data: {
+        title: 'Idempotency Test',
+        studentId: ID_ALUNO,
+        status: ExpenseRequestStatus.PENDENTE,
+        event: {
+          name: 'Evento Teste',
+          location: 'Local Teste',
+        },
+        article: { classification: 'Sem Qualis' },
+      },
+    })
+
+    await notifyStaffOnStatusChange(expense, ExpenseRequestStatus.PENDENTE, [UserRole.COORDENADOR])
+    const jobs = emitSpy.mock.calls.filter((call) => {
+      const data = call[1] as EmailJobData
+      return data.to === 'coordenador@test.com'
+    })
+
+    const firstCall = jobs[0]
+    assert(firstCall, 'Deveria ter emitido o job para o coordenador (1ª chamada)')
+    const firstCallOptions = firstCall[2] as EmitOptions | undefined
+    assert(firstCallOptions?.singletonKey, 'A opção singletonKey é obrigatória para idempotência')
+    const firstKey = firstCallOptions.singletonKey
+
+    emitSpy.mockClear()
+
+    await notifyStaffOnStatusChange(expense, ExpenseRequestStatus.PENDENTE, [UserRole.COORDENADOR])
+    const secondJobs = emitSpy.mock.calls.filter((call) => {
+      const data = call[1] as EmailJobData
+      return data.to === 'coordenador@test.com'
+    })
+
+    const secondCall = secondJobs[0]
+    assert(secondCall, 'Deveria ter emitido o job para o coordenador (2ª chamada)')
+    const secondCallOptions = secondCall[2] as EmitOptions | undefined
+    assert(secondCallOptions?.singletonKey, 'A opção singletonKey é obrigatória para idempotência')
+    const secondKey = secondCallOptions.singletonKey
+
+    expect(firstKey).toBe(secondKey)
+    expect(firstKey).toContain(`staff_notif_${expense.id}`)
+    emitSpy.mockRestore()
   })
 })

--- a/testes/backend/admin-attachment.service.test.ts
+++ b/testes/backend/admin-attachment.service.test.ts
@@ -1,4 +1,4 @@
-import { awsSendMock } from '@aws-sdk/client-s3'
+import { awsSendMock } from './mocks/aws-s3-client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const envMock = vi.hoisted(() => ({

--- a/testes/backend/expense.service.test.ts
+++ b/testes/backend/expense.service.test.ts
@@ -30,6 +30,7 @@ const prismaMock = vi.hoisted(() => ({
   },
   user: {
     findUnique: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
   },
   $transaction: vi.fn((cb) => cb(prismaMock)),
 }))

--- a/testes/backend/sprint2-flow.integration.test.ts
+++ b/testes/backend/sprint2-flow.integration.test.ts
@@ -35,6 +35,7 @@ const prismaMock = vi.hoisted(() => ({
   },
   user: {
     findUnique: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
   },
   $transaction: vi.fn((cb) => cb(prismaMock)),
 }))
@@ -59,7 +60,10 @@ const txMock = {
   costBreakdown: { create: vi.fn() },
   project: { update: vi.fn() },
   notification: { create: vi.fn() },
-  user: { findUnique: vi.fn() },
+  user: {
+    findUnique: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+  },
 }
 
 const STUDENT_ID = 'c341c8fa-724f-4ab2-9a4e-5ca55f201ad4'

--- a/testes/backend/sprint4-integration.test.ts
+++ b/testes/backend/sprint4-integration.test.ts
@@ -40,6 +40,7 @@ vi.mock('@/services/preference-survey.service', () => ({
 vi.mock('@/services/user.service', () => ({
   getUserByEmail: vi.fn(),
   getUserById: vi.fn(),
+  getUsersByRoles: vi.fn().mockResolvedValue([]),
 }))
 
 const prismaMock = vi.hoisted(() => ({
@@ -59,6 +60,7 @@ const prismaMock = vi.hoisted(() => ({
   user: {
     findUnique: vi.fn(),
     findFirst: vi.fn(),
+    findMany: vi.fn(),
     update: vi.fn(),
   },
   $transaction: vi.fn((cb: any) => cb(prismaMock)),
@@ -137,6 +139,8 @@ describe('US 4.0 — notifyStatusChange spy em updateExpenseStatus', () => {
       STUDENT_ID,
       expect.objectContaining({ id: EXPENSE_ID }),
       ExpenseRequestStatus.APROVADO,
+      null,
+      prismaMock,
     )
   })
 

--- a/testes/backend/storage.test.ts
+++ b/testes/backend/storage.test.ts
@@ -4,7 +4,7 @@
  * getSignedDownloadUrl retorna URL com expiração correta
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { awsSendMock, PutObjectCommand } from '@aws-sdk/client-s3'
+import { awsSendMock, PutObjectCommand } from './mocks/aws-s3-client'
 // alias → mocks/aws-s3-request-presigner.ts
 import { getSignedUrl as getSignedUrlMock } from '@aws-sdk/s3-request-presigner'
 


### PR DESCRIPTION
- Implement notification triggers for coordinators (Pending) and admins (Approved)
- Add new email template with academic context (QUALIS/Event)
- Add integration tests to validate notification triggers and payload consistency

* New templates
<img width="485" height="824" alt="image" src="https://github.com/user-attachments/assets/2ff9ba2f-cf61-4e56-8a25-4269e6b522f8" />


https://github.com/user-attachments/assets/e1d6bc88-3853-428d-b819-47bce2ae7bd3




