### PR TITLE
extra(refactor): use semantic codes when expired/invalid/used/archived

### DIFF
--- a/backend/src/lib/problems.ts
+++ b/backend/src/lib/problems.ts
@@ -37,7 +37,6 @@ export const PROBLEM_DEFINITIONS = {
     type: 'urn:sgda:auth:token:invalid',
     detail: 'The security token provided is invalid or has expired.',
   },
-
   // --- USER DOMAIN ---
   USER_NOT_FOUND: {
     status: 404,
@@ -65,29 +64,17 @@ export const PROBLEM_DEFINITIONS = {
   },
 
   // --- INVITE DOMAIN ---
-  INVALID_INVITE_CODE: {
-    status: 400,
-    title: 'Invalid invite code',
-    type: 'urn:sgda:domain:invite:invalid-code',
-    detail: 'The invite code provided is invalid or has expired.',
-  },
   INVITE_ALREADY_USED: {
-    status: 409,
+    status: 410,
     title: 'Invite already used',
     type: 'urn:sgda:domain:invite:already-used',
     detail: 'Cannot revoke or use an invite that has already been used.',
   },
   INVITE_ALREADY_EXPIRED: {
-    status: 409,
+    status: 410,
     title: 'Invite already expired',
     type: 'urn:sgda:domain:invite:already-expired',
     detail: 'This invite has already expired.',
-  },
-  INVITE_CONFLICT: {
-    status: 409,
-    title: 'Invite conflict',
-    type: 'urn:sgda:domain:invite:conflict',
-    detail: 'Cannot revoke or use this invite due to its current state (used or expired).',
   },
   INVITE_NOT_FOUND: {
     status: 404,
@@ -173,7 +160,7 @@ export const PROBLEM_DEFINITIONS = {
     detail: 'The project code is already in use by another project.',
   },
   PROJECT_ARCHIVED: {
-    status: 409,
+    status: 410,
     title: 'Project is archived',
     type: 'urn:sgda:domain:project:archived',
     detail: 'This project is archived and cannot be edited or linked.',

--- a/backend/src/routes/admin/invites/invites.route.ts
+++ b/backend/src/routes/admin/invites/invites.route.ts
@@ -58,6 +58,6 @@ export const remove = createRoute({
   request: { params: z.object({ id: IdSchema }) },
   responses: {
     [codes.NO_CONTENT]: { description: 'Invite revoked successfully.' },
-    ...registryResponses('INVITE_NOT_FOUND', 'INVITE_CONFLICT', 'UNAUTHORIZED', 'FORBIDDEN'),
+    ...registryResponses('INVITE_NOT_FOUND', 'INVITE_ALREADY_USED', 'INVITE_ALREADY_EXPIRED', 'UNAUTHORIZED', 'FORBIDDEN'),
   },
 })

--- a/backend/src/routes/auth/auth.handler.ts
+++ b/backend/src/routes/auth/auth.handler.ts
@@ -36,10 +36,6 @@ export const register: AppRouteHandler<RegisterRoute> = async (c) => {
   })
 
   if ('error' in result) {
-    // Mapeamento específico: No registro, se o convite não existe, tratamos como código inválido (400)
-    if (result.error === 'INVITE_NOT_FOUND') {
-      throw problems.create('INVALID_INVITE_CODE')
-    }
     throw problems.create(result.error)
   }
 

--- a/backend/src/routes/auth/auth.route.ts
+++ b/backend/src/routes/auth/auth.route.ts
@@ -26,7 +26,7 @@ export const register = createRoute({
       RegisterSuccessSchema,
       'User created successfully',
     ),
-    ...registryResponses('EMAIL_ALREADY_EXISTS', 'INVALID_INVITE_CODE', 'VALIDATION_ERROR'),
+    ...registryResponses('EMAIL_ALREADY_EXISTS', 'INVITE_NOT_FOUND', 'INVITE_ALREADY_USED', 'INVITE_ALREADY_EXPIRED', 'VALIDATION_ERROR'),
   },
 })
 

--- a/backend/tests/integration/auth/register.spec.ts
+++ b/backend/tests/integration/auth/register.spec.ts
@@ -61,7 +61,7 @@ describe('[Auth] Cadastro de usuário', () => {
 
     const res = await endpoint.$post({ json: payloadConviteInvalido })
 
-    await expectProblem(res, 'INVALID_INVITE_CODE')
+    await expectProblem(res, 'INVITE_NOT_FOUND')
   })
 
   describe('validações Semânticas (RFC 9457)', () => {

--- a/docs/planning/RFC9457_ERROR_ARCHITECTURE.md
+++ b/docs/planning/RFC9457_ERROR_ARCHITECTURE.md
@@ -46,10 +46,12 @@ Estabelecer a "Fonte da Verdade" para todos os erros da API.
 
 ### Etapa 2 — Honestidade Semântica (Atualização de HTTP Status)
 Revisar e alterar códigos de status para refletir a realidade arquitetural. As mudanças principais mapeadas:
-- **Invites**: Mudar de `400` para **`409 Conflict`** quando o convite já foi usado ou expirou (conflito de estado de negócio).
+- **Estados Terminais (410 Gone)**: Recursos que atingiram um estado terminal operacional (ex: convites usados/expirados ou projetos arquivados) agora retornam **`410 Gone`**. 
+- **Cleanup & Purge**: Alguns recursos efêmeros em estado `410`  como tokens e convites são alvos do `CleanupJob`, que realiza o purge físico dos dados após o período de retenção configurado, consolidando a semântica de que o dado "se foi".
 - **Files/Uploads**: Implementar **`415 Unsupported Media Type`** para formatos inválidos e **`413 Content Too Large`** para arquivos excedendo a cota.
-- **State Machine (Expenses)**: Transições de status inválidas mudam de falhas genéricas para **`409 Conflict`**.
+- **Conflitos (409 Conflict)**: Mantido para falhas que *podem* ser resolvidas (ex: transições de status inválidas na máquina de estados ou email já cadastrado).
 - **Resources**: Entidades não encontradas passam a retornar rigorosamente **`404 Not Found`** em todas as camadas.
+
 
 ### Etapa 3 — Equalização de Motores (Zod ↔ AJV)
 Garantir que validações estáticas (TypeScript) e dinâmicas (JSON Schema) emitam o mesmo contrato:


### PR DESCRIPTION
Follow the arquitecture doc diff for more details: [RFC9457_ERROR_ARCHITECTURE.md](https://github.com/Pratamartin/fly_costs_tool/blob/260e3076f47fa422123251a99f416b59229c53b8/docs/planning/RFC9457_ERROR_ARCHITECTURE.md)