### PR TITLE
docs(api): apply explicit schema names for enabling SDK generation

### DIFF
--- a/backend/src/routes/auth/auth.route.ts
+++ b/backend/src/routes/auth/auth.route.ts
@@ -90,7 +90,7 @@ export const logout = createRoute({
           example: 'refreshToken=; Max-Age=0; Path=/; HttpOnly',
         }),
       }),
-      content: { 'application/json': { schema: createMessageObjectSchema('Logged out successfully.') } },
+      content: { 'application/json': { schema: createMessageObjectSchema('Logged out successfully.').openapi('LogoutResponse') } },
     },
     ...registryResponses('UNAUTHORIZED'),
   },
@@ -106,7 +106,7 @@ export const forgotPassword = createRoute({
   request: { body: jsonContentRequired(ForgotPasswordSchema, 'User email') },
   responses: {
     [codes.OK]: jsonContent(
-      createMessageObjectSchema('If the email is registered, you will receive instructions to reset your password.'),
+      createMessageObjectSchema('If the email is registered, you will receive instructions to reset your password.').openapi('ForgotPasswordResponse'),
       'Generic success response to prevent user enumeration.',
     ),
     ...registryResponses('VALIDATION_ERROR'),
@@ -123,7 +123,7 @@ export const resetPassword = createRoute({
   request: { body: jsonContentRequired(ResetPasswordSchema, 'New password and token') },
   responses: {
     [codes.OK]: jsonContent(
-      createMessageObjectSchema('Password reset successfully.'),
+      createMessageObjectSchema('Password reset successfully.').openapi('ResetPasswordResponse'),
       'Password changed successfully.',
     ),
     ...registryResponses('INVALID_TOKEN', 'VALIDATION_ERROR'),

--- a/backend/src/routes/expenses/expenses.route.ts
+++ b/backend/src/routes/expenses/expenses.route.ts
@@ -9,7 +9,7 @@ import { multipartFormContentRequired } from '@/lib/util'
 import { requireAuth, requireRole, validateJsonSchema } from '@/middlewares'
 import { uploadMemorandumSettings } from '@/middlewares/upload-settings'
 import { AssignProjectResponseSchema, CreateExpenseResponseSchema, CreateExpenseSchema, ExpenseListQuerySchema, ExpenseResponseSchema, ListExpenseResponseSchema, UpdateExpenseSchema, UpdateExpenseStatusSchema, UploadMemorandumSchema } from '@/schemas/expense.schema'
-import { DeleteExpenseResponseSchema, IdSchema } from '@/schemas/shared.schema'
+import { DeleteExpenseResponseSchema, FileDownloadResponseSchema, IdSchema } from '@/schemas/shared.schema'
 
 const tags = ['Expenses']
 
@@ -144,7 +144,7 @@ export const startProcessing = createRoute({
   request: {
     params: z.object({ id: IdSchema }),
     body: jsonContent(
-      z.object({}),
+      z.object({}).openapi('StartProcessingRequest'),
       'Empty body required to initiate processing',
     ),
   },
@@ -193,10 +193,7 @@ export const getMemorandumDownload = createRoute({
   request: { params: z.object({ id: IdSchema }) },
   responses: {
     [codes.OK]: jsonContent(
-      z.object({
-        downloadUrl: z.string().url(),
-        expiresIn: z.number(),
-      }),
+      FileDownloadResponseSchema,
       'URL generated.',
     ),
     ...registryResponses('BAD_REQUEST', 'FORBIDDEN', 'EXPENSE_NOT_FOUND', 'STORAGE_UNAVAILABLE', 'UNAUTHORIZED'),

--- a/backend/src/routes/expenses/reports/reports.route.ts
+++ b/backend/src/routes/expenses/reports/reports.route.ts
@@ -25,7 +25,7 @@ export const requestReport = createRoute({
   request: { query: ExpenseReportQuerySchema },
   responses: {
     [codes.ACCEPTED]: jsonContent(
-      z.object({ jobId: z.string().uuid() }),
+      z.object({ jobId: z.string().uuid() }).openapi('RequestReportResponse'),
       'Report generation started.',
     ),
     ...registryResponses('UNAUTHORIZED', 'VALIDATION_ERROR'),

--- a/backend/src/routes/health/health.route.ts
+++ b/backend/src/routes/health/health.route.ts
@@ -9,6 +9,7 @@ export type IndexRoute = typeof index
 export const index = createRoute({
   path: '/',
   method: 'get',
+  operationId: 'checkHealth',
   summary: 'Health check',
   description: 'Checks the operational status of the API and its dependent services.',
   tags,

--- a/backend/src/routes/health/health.schema.ts
+++ b/backend/src/routes/health/health.schema.ts
@@ -8,4 +8,4 @@ export const HealthResponseSchema = z.object({
   }),
   timestamp: z.date()
     .openapi({ example: new Date().toISOString() }),
-})
+}).openapi('HealthResponse')

--- a/backend/src/routes/notifications/notifications.route.ts
+++ b/backend/src/routes/notifications/notifications.route.ts
@@ -45,7 +45,7 @@ export const markRead = createRoute({
   },
   responses: {
     [codes.OK]: jsonContent(
-      createMessageObjectSchema('Notification marked as read'),
+      createMessageObjectSchema('Notification marked as read').openapi('MarkReadResponse'),
       'Notification updated successfully.',
     ),
     ...registryResponses('UNAUTHORIZED', 'NOTIFICATION_NOT_FOUND', 'VALIDATION_ERROR'),
@@ -63,7 +63,7 @@ export const markAllRead = createRoute({
   security: [{ bearerAuth: [] }],
   responses: {
     [codes.OK]: jsonContent(
-      createMessageObjectSchema('All notifications marked as read'),
+      createMessageObjectSchema('All notifications marked as read').openapi('MarkAllReadResponse'),
       'Notifications updated successfully.',
     ),
     ...registryResponses('UNAUTHORIZED'),

--- a/backend/src/routes/preference-surveys/preference-surveys.route.ts
+++ b/backend/src/routes/preference-surveys/preference-surveys.route.ts
@@ -6,6 +6,7 @@ import { registryResponses } from '@/lib/problems'
 import { requireAuth } from '@/middlewares'
 import { uploadSurveySettings } from '@/middlewares/upload-settings'
 import { ListPreferenceSurveyResponseSchema } from '@/schemas/preference-survey.schema'
+import { FileDownloadResponseSchema } from '@/schemas/shared.schema'
 
 const tags = ['Preference Surveys']
 
@@ -46,7 +47,8 @@ export const upload = createRoute({
               type: 'string',
               format: 'binary',
               description: `File to be uploaded. Allowed formats: ${PREFERENCE_SURVEY_ALLOWED_MIME_TYPES.join(', ')}. Max ${PREFERENCE_SURVEY_UPLOAD_MAX_SIZE_MB}MB.`,
-            }),
+            })
+              .openapi('UploadSurveyRequest'),
           }),
         },
       },
@@ -57,7 +59,7 @@ export const upload = createRoute({
       z.object({
         fileKey: z.string().openapi({ description: 'File key in R2' }),
         fileName: z.string().openapi({ description: 'Original file name' }),
-      }),
+      }).openapi('UploadSurveyResponse'),
       'File uploaded successfully.',
     ),
     ...registryResponses('INVALID_FILE', 'FILE_TOO_LARGE', 'UNSUPPORTED_MEDIA_TYPE', 'UNAUTHORIZED', 'STORAGE_PROVIDER_ERROR', 'VALIDATION_ERROR'),
@@ -73,13 +75,10 @@ export const download = createRoute({
   summary: 'Get download URL',
   description: `Generates a signed, temporary S3/R2 URL to securely download a previously uploaded preference survey file using its \`fileKey\`. URL expires in **${PREFERENCE_SURVEY_DOWNLOAD_EXPIRY_SECONDS}s**.`,
   tags,
-  request: { query: z.object({ fileKey: z.string().openapi({ description: 'File key in R2' }) }) },
+  request: { query: z.object({ fileKey: z.string().openapi({ description: 'File key in R2' }) }).openapi('DownloadSurveyQuery') },
   responses: {
     [codes.OK]: jsonContent(
-      z.object({
-        downloadUrl: z.string().url(),
-        expiresIn: z.number(),
-      }),
+      FileDownloadResponseSchema,
       'URL generated successfully.',
     ),
     ...registryResponses('INVALID_FILE', 'UNAUTHORIZED', 'STORAGE_UNAVAILABLE', 'VALIDATION_ERROR'),

--- a/backend/src/schemas/admin.invite.schema.ts
+++ b/backend/src/schemas/admin.invite.schema.ts
@@ -27,6 +27,7 @@ export const CreateInviteSchema = BaseSchema.pick({
   role: true,
   expiresAt: true,
 }).superRefine(minExpiryThresholdCheck())
+  .openapi('CreateInviteRequest')
 
 export const ListInvitesQuerySchema = BaseSchema.pick({
   role: true,
@@ -39,7 +40,8 @@ export const ListInvitesQuerySchema = BaseSchema.pick({
     }),
 })
   .partial()
+  .openapi('ListInvitesQuery')
 
-export const InviteResponseSchema = BaseSchema.check(usedInviteFieldsRequired)
+export const InviteResponseSchema = BaseSchema.check(usedInviteFieldsRequired).openapi('Invite')
 
-export const ListInvitesSchema = z.array(InviteResponseSchema)
+export const ListInvitesSchema = z.array(InviteResponseSchema).openapi('InviteListResponse')

--- a/backend/src/schemas/analytics.schema.ts
+++ b/backend/src/schemas/analytics.schema.ts
@@ -19,9 +19,10 @@ export const AdminDashboardResponseSchema = z.object({
     .openapi({ example: '23450.72' }),
   budgetCommitted: z.string()
     .openapi({ example: '11230.50' }),
-})
+}).openapi('AdminDashboardResponse')
 
 export const TopProjectsQuerySchema = z.object({ limit: z.coerce.number().default(DEFAULT_TOP_PROJECTS_COUNT) }).partial()
+  .openapi('TopProjectsQuery')
 
 export const TopProjectSchema = z.object({
   id: IdSchema,
@@ -31,6 +32,6 @@ export const TopProjectSchema = z.object({
     .openapi({ example: 18 }),
   totalValue: z.string()
     .openapi({ example: '7800.45' }),
-})
+}).openapi('TopProject')
 
-export const TopProjectsResponseSchema = z.array(TopProjectSchema)
+export const TopProjectsResponseSchema = z.array(TopProjectSchema).openapi('TopProjectListResponse')

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -36,28 +36,28 @@ export const StaffRegisterSchema = RegisterBaseSchema
 export const RegisterSchema = z.discriminatedUnion('role', [
   StaffRegisterSchema.strict(),
   AlunoRegisterSchema,
-])
+]).openapi('RegisterUserRequest')
 
 export const RegisterSuccessSchema = UserSchema
 
 export const LoginSchema = RegisterBaseSchema.pick({
   email: true,
   password: true,
-})
+}).openapi('LoginUserRequest')
 
 export const LoginSuccessSchema = z.object({
   accessToken: z.string().openapi({
     description: 'JWT (JSON Web Token) to be used in the authorization header.',
     example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
   }),
-})
+}).openapi('LoginResponse')
 
 export const ForgotPasswordSchema = z.object({
   email: z.email()
     .openapi({ example: MOCK_USER.email }),
-})
+}).openapi('ForgotPasswordRequest')
 
 export const ResetPasswordSchema = z.object({
   token: z.string().openapi({ example: 'plain-token-here' }),
   newPassword: RegisterBaseSchema.shape.password,
-})
+}).openapi('ResetPasswordRequest')

--- a/backend/src/schemas/cost-breakdown.schema.ts
+++ b/backend/src/schemas/cost-breakdown.schema.ts
@@ -22,7 +22,7 @@ const BaseSchema = z.object({
     .openapi({ description: 'Receipt key in R2 storage. Can be used during registration to reuse a previously uploaded file.' }),
 })
 
-export const CreateCostBreakdownSchema = BaseSchema.omit({ id: true })
+export const CreateCostBreakdownSchema = BaseSchema.omit({ id: true }).openapi('CreateCostBreakdownRequest')
 
 export const CostBreakdownResponseSchema = z.object({
   id: IdSchema,
@@ -40,7 +40,7 @@ export const CostBreakdownResponseSchema = z.object({
   attachmentKey: z.string().nullable()
     .optional()
     .openapi({ description: 'Receipt key in R2 storage.' }),
-})
+}).openapi('CostBreakdown')
 
 export const UploadReceiptSchema = z.object({
   file: FileItemSchema.superRefine(validReceiptFileCheck(RECEIPT_UPLOAD_MAX_SIZE_MB))
@@ -49,7 +49,7 @@ export const UploadReceiptSchema = z.object({
       format: 'binary',
       description: `Receipt file (PDF, JPG, PNG). Maximum size allowed: ${RECEIPT_UPLOAD_MAX_SIZE_MB}MB.`,
     }),
-})
+}).openapi('UploadReceiptRequest')
 
 export const ReceiptDownloadUrlSchema = z.object({
   url: z.url()
@@ -62,4 +62,4 @@ export const ReceiptDownloadUrlSchema = z.object({
       description: 'URL expiration time in seconds',
       example: COST_BREAKDOWN_RECEIPT_DOWNLOAD_URL_EXPIRY_SECONDS,
     }),
-})
+}).openapi('ReceiptDownloadResponse')

--- a/backend/src/schemas/expense.category.schema.ts
+++ b/backend/src/schemas/expense.category.schema.ts
@@ -8,8 +8,8 @@ const BaseSchema = z.object({
   normalizedName: z.string().openapi({ example: 'uber' }),
 })
 
-export const ExpenseCategoryResponseSchema = BaseSchema.extend(TimestampSchema)
-export const ListExpenseCategoryResponseSchema = z.array(ExpenseCategoryResponseSchema)
+export const ExpenseCategoryResponseSchema = BaseSchema.extend(TimestampSchema).openapi('ExpenseCategory')
+export const ListExpenseCategoryResponseSchema = z.array(ExpenseCategoryResponseSchema).openapi('ExpenseCategoryListResponse')
 
 export const ListExpenseCategoryQuerySchema = z.object({
   search: z.string().optional()
@@ -18,17 +18,19 @@ export const ListExpenseCategoryQuerySchema = z.object({
       example: 'passagem',
     }),
 }).partial()
+  .openapi('ListExpenseCategoriesQuery')
 
 export const CreateExpenseCategorySchema = z.object({
   name: z.string().min(2)
     .trim()
     .openapi({ example: 'Uber' }),
 
-}).transform((data) => {
-  return {
-    name: data.name,
-    normalizedName: normalizeCategoryName(data.name),
-  }
-})
+}).openapi('CreateExpenseCategoryRequest')
+  .transform((data) => {
+    return {
+      name: data.name,
+      normalizedName: normalizeCategoryName(data.name),
+    }
+  })
 
 export default BaseSchema

--- a/backend/src/schemas/expense.forms.schema.ts
+++ b/backend/src/schemas/expense.forms.schema.ts
@@ -7,7 +7,7 @@ export const EventFormSchema = z.object({
     example: eventJSONSchema,
   }),
   ui: z.object().openapi({ example: eventJSONUi }),
-})
+}).openapi('EventForm')
 
 export const ArticleFormSchema = z.object({
   schema: z.fromJSONSchema(articleJSONSchema as any, { defaultTarget: 'draft-7' }).openapi({
@@ -15,9 +15,9 @@ export const ArticleFormSchema = z.object({
     example: articleJSONSchema,
   }),
   ui: z.object().openapi({ example: articleJSONUi }),
-})
+}).openapi('ArticleForm')
 
 export const FormsResponseSchema = z.object({
   event: EventFormSchema,
   article: ArticleFormSchema,
-})
+}).openapi('FormsResponse')

--- a/backend/src/schemas/expense.schema.ts
+++ b/backend/src/schemas/expense.schema.ts
@@ -79,6 +79,7 @@ export const CreateExpenseSchema = BaseSchema.omit({
   surveyAnswers: z.array(PreferenceSurveyAnswerSchema).min(1, { message: 'Select at least one preference to continue.' })
     .openapi({ description: 'List of categories and requested form responses' }),
 })
+  .openapi('CreateExpenseRequest')
 
 export const ExpenseResponseSchema = z.object({ id: IdSchema })
   .extend({
@@ -95,8 +96,10 @@ export const ExpenseResponseSchema = z.object({ id: IdSchema })
     })).optional()
       .openapi({ description: 'List of submitted preference surveys (e.g. flights, daily allowances, registrations)' }),
   })
+  .openapi('Expense')
 
 export const ExpenseListQuerySchema = BaseSchema.pick({ status: true }).partial()
+  .openapi('ListExpensesQuery')
 
 export const ExpenseListItemSchema = z.object({
   id: IdSchema,
@@ -122,8 +125,9 @@ export const ExpenseListItemSchema = z.object({
     })).optional()
       .openapi({ description: 'List of submitted preference surveys (e.g. flights, daily allowances, registrations)' }),
   })
+  .openapi('ExpenseListItem')
 
-export const ListExpenseResponseSchema = z.array(ExpenseListItemSchema)
+export const ListExpenseResponseSchema = z.array(ExpenseListItemSchema).openapi('ExpenseListResponse')
 
 export const UpdateExpenseStatusSchema = z.object({
   status: z.enum([ExpenseRequestStatus.APROVADO, ExpenseRequestStatus.REJEITADO, ExpenseRequestStatus.EM_EDICAO]).openapi({
@@ -137,6 +141,7 @@ export const UpdateExpenseStatusSchema = z.object({
       example: 'Documentação pendente: Realize o ajuste necessário.',
     }),
 }).check(reasonFieldRequired)
+  .openapi('UpdateExpenseStatusRequest')
 
 export const UploadMemorandumSchema = z.object({
   file: FileItemSchema
@@ -146,11 +151,11 @@ export const UploadMemorandumSchema = z.object({
       format: 'binary',
     })
     .superRefine(validPDFCheck(MEMORANDUM_UPLOAD_MAX_SIZE_MB)),
-})
+}).openapi('UploadMemorandumRequest')
 
-export const CreateExpenseResponseSchema = ExpenseResponseSchema.extend({ status: z.literal(ExpenseRequestStatus.PENDENTE) })
+export const CreateExpenseResponseSchema = ExpenseResponseSchema.extend({ status: z.literal(ExpenseRequestStatus.PENDENTE) }).openapi('CreateExpenseResponse')
 
-export const AssignProjectResponseSchema = ExpenseResponseSchema.extend({ status: z.literal(ExpenseRequestStatus.EM_PROCESSAMENTO) })
+export const AssignProjectResponseSchema = ExpenseResponseSchema.extend({ status: z.literal(ExpenseRequestStatus.EM_PROCESSAMENTO) }).openapi('StartProcessingResponse')
 
 export const UpdateExpenseSchema = BaseSchema
   .pick({
@@ -165,6 +170,7 @@ export const UpdateExpenseSchema = BaseSchema
       .optional()
       .openapi({ description: 'List of categories and requested form responses' }),
   })
+  .openapi('UpdateExpenseRequest')
 
 export const ExpenseReportQuerySchema = z.object({
   from: z.coerce.date().optional()
@@ -184,4 +190,4 @@ export const ExpenseReportQuerySchema = z.object({
     }),
   projectId: IdSchema.optional().openapi({ description: 'Filter by project' }),
   studentId: IdSchema.optional().openapi({ description: 'Filter by student' }),
-})
+}).openapi('ExpenseReportQuery')

--- a/backend/src/schemas/notification.schema.ts
+++ b/backend/src/schemas/notification.schema.ts
@@ -28,9 +28,9 @@ export const NotificationSchema = z.object({
     updatedAt: z.coerce.date().openapi({ description: 'Last update time of the expense request' }),
   }).nullable()
     .openapi({ description: 'Snapshot of the related expense request' }),
-}).openapi({ description: 'A user notification' })
+}).openapi('Notification')
 
-export const NotificationsListSchema = z.array(NotificationSchema)
+export const NotificationsListSchema = z.array(NotificationSchema).openapi('NotificationListResponse')
 
 export const NotificationQuerySchema = PaginationSchema.extend({
   unreadOnly: z.coerce.boolean()
@@ -40,3 +40,4 @@ export const NotificationQuerySchema = PaginationSchema.extend({
       description: 'Filter only by unread notifications',
     }),
 }).partial()
+  .openapi('ListNotificationsQuery')

--- a/backend/src/schemas/preference-survey.schema.ts
+++ b/backend/src/schemas/preference-survey.schema.ts
@@ -10,6 +10,7 @@ export const DynamicSurveyDataSchema = z.record(z.string(), z.any()).openapi({
     preferenceSurveyJSONSchema.definitions['passagem-aerea'] as any,
   ],
 })
+  .openapi('DynamicSurveyData')
 
 export const PreferenceSurveySchema = z.object({
   id: IdSchema,
@@ -25,10 +26,11 @@ export const PreferenceSurveySchema = z.object({
     normalizedName: z.string().openapi({ example: 'inscricao' }),
   }),
 }).extend(TimestampSchema)
+  .openapi('PreferenceSurvey')
 
-export const ListPreferenceSurveyResponseSchema = z.array(PreferenceSurveySchema)
+export const ListPreferenceSurveyResponseSchema = z.array(PreferenceSurveySchema).openapi('PreferenceSurveyListResponse')
 
 export const PreferenceSurveyAnswerSchema = z.object({
   expenseCategoryId: IdSchema,
   data: DynamicSurveyDataSchema,
-})
+}).openapi('PreferenceSurveyAnswer')

--- a/backend/src/schemas/project.schema.ts
+++ b/backend/src/schemas/project.schema.ts
@@ -43,13 +43,14 @@ const BaseSchema = z.object({
     .openapi({ example: dummyExpenseCategories.map(c => c.normalizedName) }),
 })
 
-export const CreateProjectSchema = BaseSchema.check(projectPeriodCheck)
+export const CreateProjectSchema = BaseSchema.check(projectPeriodCheck).openapi('CreateProjectRequest')
 
 export const UpdateProjectSchema = BaseSchema.omit({
   budget: true,
   startDate: true,
   endDate: true,
 }).partial()
+  .openapi('UpdateProjectRequest')
 
 export const UpdateProjectPeriodSchema = z.object({
   startDate: z.coerce.date().openapi({
@@ -61,6 +62,7 @@ export const UpdateProjectPeriodSchema = z.object({
     description: 'Project validity end date.',
   }),
 }).check(projectPeriodCheck)
+  .openapi('UpdateProjectPeriodRequest')
 
 export const ProjectResponseSchema = z.object({ id: IdSchema })
   .extend(BaseSchema.shape)
@@ -73,6 +75,7 @@ export const ProjectResponseSchema = z.object({ id: IdSchema })
       .default(true),
   })
   .extend(TimestampSchema)
+  .openapi('Project')
 
 export const ListProjectQuerySchema = z.object({
   isActive: z.coerce.boolean().openapi({ example: true })
@@ -83,7 +86,8 @@ export const ListProjectQuerySchema = z.object({
       example: 'Alpha',
     }),
 }).partial()
+  .openapi('ListProjectsQuery')
 
-export const ListProjectResponseSchema = z.array(ProjectResponseSchema)
+export const ListProjectResponseSchema = z.array(ProjectResponseSchema).openapi('ProjectListResponse')
 
 export default BaseSchema

--- a/backend/src/schemas/report.schema.ts
+++ b/backend/src/schemas/report.schema.ts
@@ -5,7 +5,7 @@ export const ReportEventEnumSchema = z.enum([
   REPORT_SSE_EVENTS.UPDATE,
   REPORT_SSE_EVENTS.FINISHED,
   REPORT_SSE_EVENTS.ERROR,
-])
+]).openapi('ReportEventEnum')
 
 export const ReportEventDataSchema = z.discriminatedUnion('status', [
   z.object({
@@ -24,6 +24,6 @@ export const ReportEventDataSchema = z.discriminatedUnion('status', [
   }),
   z.object({ status: z.literal(REPORT_SSE_STATUS.NOT_FOUND).openapi({ example: REPORT_SSE_STATUS.NOT_FOUND }) }),
   z.object({ status: z.enum(['active', 'created', 'retry', 'waiting', 'cancelled']).openapi({ example: 'active' }) }),
-])
+]).openapi('ReportEventData')
 
 export type ReportSSEEvent = z.infer<typeof ReportEventDataSchema>

--- a/backend/src/schemas/shared.schema.ts
+++ b/backend/src/schemas/shared.schema.ts
@@ -78,7 +78,7 @@ export const FileUploadErrorSchema = z.object({
 
 export type FileUploadError = z.infer<typeof FileUploadErrorSchema>
 
-export const DeleteExpenseResponseSchema = z.object({ success: z.literal(true) }).openapi({ description: 'Standard success response for delete operations.' })
+export const DeleteExpenseResponseSchema = z.object({ success: z.literal(true) }).openapi('DeleteExpenseResponse')
 
 export const ProjectPeriodExpiredSchema = z.object({
   projectStartDate: z.string().nullable()
@@ -143,3 +143,9 @@ export const InvalidSubcategoriesSchema = z.object({
       example: 0,
     }),
 })
+
+export const FileDownloadResponseSchema = z.object({
+  downloadUrl: z.string().url()
+    .openapi({ description: 'Signed URL for downloading the file' }),
+  expiresIn: z.number().openapi({ description: 'Expiration time of the URL in seconds' }),
+}).openapi('FileDownloadResponse')

--- a/backend/src/schemas/user.schema.ts
+++ b/backend/src/schemas/user.schema.ts
@@ -57,7 +57,7 @@ export const ProfileSchema = z.object({
         'b4d9bf08-b854-4647-b564-8a407a229230',
       ],
     }),
-})
+}).openapi('Profile')
 
 export const UserSchema = z.object({
   id: IdSchema,
@@ -76,6 +76,7 @@ export const UserSchema = z.object({
   })
     .nullish(),
 }).extend(TimestampSchema)
+  .openapi('User')
 
 export const UpdateProfileSchema = ProfileSchema.partial().extend({
   name: z.string()
@@ -85,3 +86,4 @@ export const UpdateProfileSchema = ProfileSchema.partial().extend({
       description: 'Optional user name update',
     }),
 })
+  .openapi('UpdateProfileRequest')


### PR DESCRIPTION
- In the models section, we already had the problem registry errors mapped out, now we define all of the request/response types explicitly by simply naming them in the Zod schemas with the `openapi()` property, so that they show up there.
Example:
<img width="1304" height="804" alt="image" src="https://github.com/user-attachments/assets/7ecbd58e-91d2-4bf4-9523-da8043363b42" />

